### PR TITLE
allow comments and trailing commas in json

### DIFF
--- a/RePak/src/RePak.cpp
+++ b/RePak/src/RePak.cpp
@@ -34,7 +34,7 @@ int main(int argc, char** argv)
 
     Document doc{ };
 
-    doc.ParseStream(isw);
+    doc.ParseStream<rapidjson::ParseFlag::kParseCommentsFlag | rapidjson::ParseFlag::kParseTrailingCommasFlag>(isw);
 
     // handle parse errors
     if (doc.HasParseError()) {


### PR DESCRIPTION
This matches northstar's json parsing, and is in general just nice to have