### PR TITLE
Shader packing

### DIFF
--- a/src/RePak.vcxproj
+++ b/src/RePak.vcxproj
@@ -30,6 +30,7 @@
     </ClCompile>
     <ClCompile Include="utils\dxutils.cpp" />
     <ClCompile Include="utils\logger.cpp" />
+    <ClCompile Include="utils\strutils.cpp" />
     <ClCompile Include="utils\utils.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -95,6 +96,7 @@
     <ClInclude Include="utils\binaryio.h" />
     <ClInclude Include="utils\dxutils.h" />
     <ClInclude Include="utils\logger.h" />
+    <ClInclude Include="utils\strutils.h" />
     <ClInclude Include="utils\utils.h" />
   </ItemGroup>
   <ItemGroup>

--- a/src/RePak.vcxproj
+++ b/src/RePak.vcxproj
@@ -29,6 +29,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="utils\dxutils.cpp" />
+    <ClCompile Include="utils\jsonutils.cpp" />
     <ClCompile Include="utils\logger.cpp" />
     <ClCompile Include="utils\strutils.cpp" />
     <ClCompile Include="utils\utils.cpp" />
@@ -95,6 +96,7 @@
     <ClInclude Include="thirdparty\rapidjson\writer.h" />
     <ClInclude Include="utils\binaryio.h" />
     <ClInclude Include="utils\dxutils.h" />
+    <ClInclude Include="utils\jsonutils.h" />
     <ClInclude Include="utils\logger.h" />
     <ClInclude Include="utils\strutils.h" />
     <ClInclude Include="utils\utils.h" />

--- a/src/RePak.vcxproj
+++ b/src/RePak.vcxproj
@@ -45,6 +45,7 @@
     <ClInclude Include="public\animrig.h" />
     <ClInclude Include="public\material.h" />
     <ClInclude Include="public\materialflags.h" />
+    <ClInclude Include="public\multishader.h" />
     <ClInclude Include="public\rpak.h" />
     <ClInclude Include="public\shader.h" />
     <ClInclude Include="public\shaderset.h" />

--- a/src/RePak.vcxproj.filters
+++ b/src/RePak.vcxproj.filters
@@ -96,6 +96,9 @@
     <ClCompile Include="assets\shader.cpp">
       <Filter>assets</Filter>
     </ClCompile>
+    <ClCompile Include="utils\strutils.cpp">
+      <Filter>utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="assets\assets.h">
@@ -286,6 +289,9 @@
     </ClInclude>
     <ClInclude Include="public\multishader.h">
       <Filter>public</Filter>
+    </ClInclude>
+    <ClInclude Include="utils\strutils.h">
+      <Filter>utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/RePak.vcxproj.filters
+++ b/src/RePak.vcxproj.filters
@@ -284,6 +284,9 @@
     <ClInclude Include="public\shader.h">
       <Filter>public</Filter>
     </ClInclude>
+    <ClInclude Include="public\multishader.h">
+      <Filter>public</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="cpp.hint" />

--- a/src/RePak.vcxproj.filters
+++ b/src/RePak.vcxproj.filters
@@ -99,6 +99,9 @@
     <ClCompile Include="utils\strutils.cpp">
       <Filter>utils</Filter>
     </ClCompile>
+    <ClCompile Include="utils\jsonutils.cpp">
+      <Filter>utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="assets\assets.h">
@@ -291,6 +294,9 @@
       <Filter>public</Filter>
     </ClInclude>
     <ClInclude Include="utils\strutils.h">
+      <Filter>utils</Filter>
+    </ClInclude>
+    <ClInclude Include="utils\jsonutils.h">
       <Filter>utils</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/assets/animseq.cpp
+++ b/src/assets/animseq.cpp
@@ -50,7 +50,8 @@ void Assets::AddAnimSeqAsset(CPakFile* pak, const char* assetPath)
     rmem dataBuf(dataChunk.Data());
     dataBuf.seek(rseqNameLenAligned + seqdesc.autolayerindex, rseekdir::beg);
 
-    // register autolayer aseq guids
+    // Iterate over each of the sequence's autolayers to register each of the autolayer GUIDs
+    // This is required as otherwise the game will crash while trying to dereference a non-converted GUID.
     for (int i = 0; i < seqdesc.numautolayers; ++i)
     {
         dataBuf.seek(rseqNameLenAligned + seqdesc.autolayerindex + (i * sizeof(mstudioautolayer_t)), rseekdir::beg);
@@ -62,6 +63,7 @@ void Assets::AddAnimSeqAsset(CPakFile* pak, const char* assetPath)
 
         PakAsset_t* asset = pak->GetAssetByGuid(autolayer->guid);
 
+        // If the autolayer's guid is present in the same RPak, add this ASEQ asset to the referenced asset's dependents.
         if (asset)
             pak->SetCurrentAssetAsDependentForAsset(asset);
     }

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -29,5 +29,6 @@ namespace Assets
 
 	void AddShaderSetAsset_v8(CPakFile* pak, const char* assetPath, rapidjson::Value& mapEntry);
 	void AddShaderAsset_v8(CPakFile* pak, const char* assetPath, rapidjson::Value& mapEntry);
+	void AddShaderAsset_v12(CPakFile* pak, const char* assetPath, rapidjson::Value& mapEntry);
 
 };

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -12,7 +12,7 @@ namespace Assets
 {
 	void AddPatchAsset(CPakFile* pak, const char* assetPath, rapidjson::Value& mapEntry);
 
-	void AddTextureAsset(CPakFile* pak, const char* assetPath, bool forceDisableStreaming, bool materialGeneratedTexture);
+	void AddTextureAsset(CPakFile* pak, const uint64_t guid, const char* assetPath, bool forceDisableStreaming, bool materialGeneratedTexture);
 	void AddTextureAsset_v8(CPakFile* pak, const char* assetPath, rapidjson::Value& mapEntry);
 
 	void AddMaterialAsset_v12(CPakFile* pak, const char* assetPath, rapidjson::Value& mapEntry);

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -28,6 +28,7 @@ namespace Assets
 	void AddAnimRigAsset_v4(CPakFile* pak, const char* assetPath, rapidjson::Value& mapEntry);
 
 	void AddShaderSetAsset_v8(CPakFile* pak, const char* assetPath, rapidjson::Value& mapEntry);
+	void AddShaderSetAsset_v11(CPakFile* pak, const char* assetPath, rapidjson::Value& mapEntry);
 	void AddShaderAsset_v8(CPakFile* pak, const char* assetPath, rapidjson::Value& mapEntry);
 	void AddShaderAsset_v12(CPakFile* pak, const char* assetPath, rapidjson::Value& mapEntry);
 

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -12,7 +12,7 @@ namespace Assets
 {
 	void AddPatchAsset(CPakFile* pak, const char* assetPath, rapidjson::Value& mapEntry);
 
-	void AddTextureAsset(CPakFile* pak, const uint64_t guid, const char* assetPath, bool forceDisableStreaming, bool materialGeneratedTexture);
+	void AddTextureAsset(CPakFile* pak, uint64_t guid, const char* assetPath, bool forceDisableStreaming, bool materialGeneratedTexture);
 	void AddTextureAsset_v8(CPakFile* pak, const char* assetPath, rapidjson::Value& mapEntry);
 
 	void AddMaterialAsset_v12(CPakFile* pak, const char* assetPath, rapidjson::Value& mapEntry);

--- a/src/assets/material.cpp
+++ b/src/assets/material.cpp
@@ -176,7 +176,7 @@ void MaterialAsset_t::FromJSON(rapidjson::Value& mapEntry)
 
     // optional shaderset override
     if (JSON_IS_STR(mapEntry, "shaderset"))
-        this->shaderSet = RTech::GetAssetGUIDFromString(mapEntry["shaderset"].GetString());
+        this->shaderSet = RTech::GetAssetGUIDFromString(mapEntry["shaderset"].GetString(), true);
 
     // this is more desirable but would break guid input
     /*if (JSON_IS_STR(mapEntry, "shaderset"))

--- a/src/assets/material.cpp
+++ b/src/assets/material.cpp
@@ -20,7 +20,7 @@ void Material_CreateTextures(CPakFile* pak, rapidjson::Value& mapEntry)
             if (RTech::ParseGUIDFromString(it.GetString()))
                 continue;
 
-            Assets::AddTextureAsset(pak, it.GetString(), JSON_GET_BOOL(mapEntry, "disableStreaming"), true);
+            Assets::AddTextureAsset(pak, 0, it.GetString(), JSON_GET_BOOL(mapEntry, "disableStreaming"), true);
         }
     }
     else if (JSON_IS_OBJECT(mapEntry, "textures"))
@@ -37,7 +37,7 @@ void Material_CreateTextures(CPakFile* pak, rapidjson::Value& mapEntry)
             if (RTech::ParseGUIDFromString(it.value.GetString()))
                 continue;
 
-            Assets::AddTextureAsset(pak, it.value.GetString(), JSON_GET_BOOL(mapEntry, "disableStreaming"), true);
+            Assets::AddTextureAsset(pak, 0, it.value.GetString(), JSON_GET_BOOL(mapEntry, "disableStreaming"), true);
         }
     }
 

--- a/src/assets/material.cpp
+++ b/src/assets/material.cpp
@@ -43,6 +43,155 @@ void Material_CreateTextures(CPakFile* pak, rapidjson::Value& mapEntry)
 
 }
 
+#define DEFAULT_UNK_FLAGS 0x4
+#define DEFAULT_DEPTH_STENCIL_FLAGS 0x17
+#define DEFAULT_RASTERIZER_FLAGS 0x6
+
+static bool ParseDXStateFlags(const rapidjson::Value& mapEntry, int& unkFlags, int& depthStencilFlags, int& rasterizerFlags)
+{
+    // dx flags
+    // !!!temp!!! - these should be replaced by proper flag string parsing when possible
+    unkFlags = DEFAULT_UNK_FLAGS;
+    depthStencilFlags = DEFAULT_DEPTH_STENCIL_FLAGS;
+    rasterizerFlags = DEFAULT_RASTERIZER_FLAGS; // CULL_BACK
+
+    JSON_GetValue(mapEntry, "unkFlags", JSONFieldType_e::kNumber, unkFlags);
+    JSON_GetValue(mapEntry, "depthStencilFlags", JSONFieldType_e::kNumber, depthStencilFlags);
+    JSON_GetValue(mapEntry, "rasterizerFlags", JSONFieldType_e::kNumber, rasterizerFlags);
+
+    return true;
+}
+
+template <size_t BLEND_STATE_COUNT>
+static bool ParseBlendStateFlags(const rapidjson::Value& mapEntry, unsigned int blendStates[BLEND_STATE_COUNT])
+{
+    rapidjson::Document::ConstMemberIterator blendStatesIt;
+    const bool hasField = JSON_GetIterator(mapEntry, "blendStates", blendStatesIt);
+
+    if (!hasField)
+        return false;
+
+    const rapidjson::Value& blendStateJson = blendStatesIt->value;
+
+    if (blendStateJson.IsArray())
+    {
+        const rapidjson::Value::ConstArray blendStateElems = blendStateJson.GetArray();
+        const int numBlendStates = static_cast<int>(blendStateElems.Size());
+
+        if (numBlendStates != BLEND_STATE_COUNT)
+        {
+            Error("Expected %i blend state flags, found %i\n", BLEND_STATE_COUNT, numBlendStates);
+            return false;
+        }
+
+        for (int i = 0; i < numBlendStates; i++)
+        {
+            const rapidjson::Value& obj = blendStateElems[i];
+            const rapidjson::Type type = obj.GetType();
+
+            if (type == rapidjson::kNumberType)
+                blendStates[i] = obj.GetUint();
+            else if (type == rapidjson::kStringType)
+            {
+                const char* const startPtr = obj.GetString();
+                char* endPtr;
+
+                const unsigned int result = strtoul(startPtr, &endPtr, 16);
+
+                if (endPtr != &startPtr[obj.GetStringLength()])
+                {
+                    Error("Failed parsing blend state flag #%i (%s)\n", (int)i, startPtr);
+                    return false;
+                }
+
+                blendStates[i] = result;
+            }
+            else
+            {
+                Error("Unsupported type for blend state flag #i (got %s, expected %s)\n", (int)i,
+                    JSON_TypeToString(type), JSON_TypeToString(rapidjson::kStringType));
+
+                return false;
+            }
+        }
+    }
+    else if (blendStateJson.IsString()) // Split the flags from provided string.
+    {
+        const std::vector<std::string> blendStateElems = Utils::StringSplit(blendStateJson.GetString(), ' ');
+        const int numBlendStates = static_cast<int>(blendStateElems.size());
+
+        if (numBlendStates != BLEND_STATE_COUNT)
+        {
+            Error("Expected %i blend state flags, found %i\n", BLEND_STATE_COUNT, numBlendStates);
+            return false;
+        }
+
+        for (int i = 0; i < BLEND_STATE_COUNT; i++)
+        {
+            const std::string& val = blendStateElems[i];
+
+            const char* const startPtr = val.c_str();
+            char* endPtr;
+
+            const unsigned int result = strtoul(startPtr, &endPtr, 16);
+
+            if (endPtr != &startPtr[val.length()])
+            {
+                Error("Failed parsing blend state flag #%i (%s)\n", i, startPtr);
+                return false;
+            }
+            else
+                blendStates[i] = result;
+        }
+    }
+    else
+    {
+        Error("Unsupported type for blend state flags (got %s, expected %s or %s)\n",
+            JSON_TypeToString(blendStateJson.GetType()), JSON_TypeToString(rapidjson::kArrayType),
+            JSON_TypeToString(rapidjson::kStringType));
+
+        return false;
+    }
+
+    return true;
+}
+
+template <typename MaterialDXState_t>
+static void SetDXStates(const rapidjson::Value& mapEntry, MaterialDXState_t dxStates[MAT_DX_STATE_COUNT])
+{
+    int unkFlags, depthStencilFlags, rasterizerFlags;
+    ParseDXStateFlags(mapEntry, unkFlags, depthStencilFlags, rasterizerFlags);
+
+    static const int totalBlendStateCount = ARRAYSIZE(dxStates[0].blendStates);
+
+    unsigned int blendStateMap[totalBlendStateCount];
+    const bool hasBlendStates = ParseBlendStateFlags<totalBlendStateCount>(mapEntry, blendStateMap);
+
+    for (int i = 0; i < MAT_DX_STATE_COUNT; i++)
+    {
+        MaterialDXState_t& dxState = dxStates[i];
+
+        dxState.unk = unkFlags;
+        dxState.depthStencilFlags = (uint16_t)depthStencilFlags;
+        dxState.rasterizerFlags = (uint16_t)rasterizerFlags;
+
+        for (int j = 0; j < ARRAYSIZE(dxState.blendStates); j++)
+        {
+            MaterialBlendState_t& blendState = dxState.blendStates[j];
+
+            if (!hasBlendStates) // Default it off.
+            {
+                // todo(amos): is there a reason we default to setting all
+                // bits for renderTargetWriteMask ?
+                blendState = MaterialBlendState_t(0xF0000000);
+                continue;
+            }
+
+            blendState = MaterialBlendState_t(blendStateMap[j]);
+        }
+    }
+}
+
 void MaterialAsset_t::SetupDepthMaterialOverrides(const rapidjson::Value& mapEntry)
 {
     std::string depthPath;
@@ -118,22 +267,7 @@ void MaterialAsset_t::FromJSON(rapidjson::Value& mapEntry)
     else
         this->flags2 = (0x56000020 | 0x10000000000000); // beeg flag is used on most things
 
-    // dx flags
-    // !!!temp!!! - these should be replaced by proper flag string parsing when possible
-    const int unkFlags = JSON_GET_INT(mapEntry, "unkFlags", 0x4);
-    const short depthStencilFlags = (short)JSON_GET_INT(mapEntry, "depthStencilFlags", 0x17);
-    const short rasterizerFlags   = (short)JSON_GET_INT(mapEntry, "rasterizerFlags", 0x6); // CULL_BACK
-
-    for (int i = 0; i < 2; ++i)
-    {
-        // set default as apex values, set r2 later if needed
-        for (int j = 0; j < 8; ++j)
-            this->dxStates[i].blendStates[j] = MaterialBlendState_t(false, 0xf);
-
-        this->dxStates[i].unk = unkFlags;
-        this->dxStates[i].depthStencilFlags = depthStencilFlags;
-        this->dxStates[i].rasterizerFlags = rasterizerFlags;
-    }
+    SetDXStates(mapEntry, dxStates);
 
     // surfaces are defined in scripts/surfaceproperties.txt or scripts/surfaceproperties.rson
     this->surface = JSON_GET_STR(mapEntry, "surface", "default");
@@ -319,7 +453,7 @@ void Material_SetTitanfall2Preset(MaterialAsset_t* material, const std::string& 
     if (presetName == "none")
         return;
 
-    MaterialDXState_t& dxState = material->dxStates[0];
+    MaterialDXState_v15_t& dxState = material->dxStates[0];
 
     bool useDefaultBlendStates = true;
 
@@ -342,10 +476,10 @@ void Material_SetTitanfall2Preset(MaterialAsset_t* material, const std::string& 
     {
         useDefaultBlendStates = false;
 
-        dxState.blendStates[0] = MaterialBlendState_t(false, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
-        dxState.blendStates[1] = MaterialBlendState_t(false, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
-        dxState.blendStates[2] = MaterialBlendState_t(false, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
-        dxState.blendStates[3] = MaterialBlendState_t(false, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0x0);
+        dxState.blendStates[0] = MaterialBlendState_t(false, false, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
+        dxState.blendStates[1] = MaterialBlendState_t(false, false, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
+        dxState.blendStates[2] = MaterialBlendState_t(false, false, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
+        dxState.blendStates[3] = MaterialBlendState_t(false, false, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0x0);
 
         dxState.unk = 4;
     }
@@ -360,13 +494,13 @@ void Material_SetTitanfall2Preset(MaterialAsset_t* material, const std::string& 
     if (useDefaultBlendStates)
     {
         // 0xF0138286
-        dxState.blendStates[0] = MaterialBlendState_t(true, D3D11_BLEND_ONE, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
+        dxState.blendStates[0] = MaterialBlendState_t(false, true, D3D11_BLEND_ONE, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
         // 0xF0138286
-        dxState.blendStates[1] = MaterialBlendState_t(true, D3D11_BLEND_ONE, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
+        dxState.blendStates[1] = MaterialBlendState_t(false, true, D3D11_BLEND_ONE, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
         // 0xF0008286
-        dxState.blendStates[2] = MaterialBlendState_t(true, D3D11_BLEND_ONE, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_OP_ADD, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, 0xF);
+        dxState.blendStates[2] = MaterialBlendState_t(false, true, D3D11_BLEND_ONE, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_OP_ADD, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, 0xF);
         // 0x00138286
-        dxState.blendStates[3] = MaterialBlendState_t(true, D3D11_BLEND_ONE, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0);
+        dxState.blendStates[3] = MaterialBlendState_t(false, true, D3D11_BLEND_ONE, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0);
 
         dxState.unk = 5;
     }
@@ -423,24 +557,24 @@ void Assets::AddMaterialAsset_v12(CPakFile* pak, const char* assetPath, rapidjso
     {
         for (int i = 0; i < 2; ++i)
         {
-            MaterialDXState_t& dxState = matlAsset->dxStates[i];
+            MaterialDXState_v15_t& dxState = matlAsset->dxStates[i];
 
-            dxState.blendStates[0] = MaterialBlendState_t(false, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
-            dxState.blendStates[1] = MaterialBlendState_t(false, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
-            dxState.blendStates[2] = MaterialBlendState_t(false, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
-            dxState.blendStates[3] = MaterialBlendState_t(false, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0x0);
+            dxState.blendStates[0] = MaterialBlendState_t(false, false, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
+            dxState.blendStates[1] = MaterialBlendState_t(false, false, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
+            dxState.blendStates[2] = MaterialBlendState_t(false, false, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
+            dxState.blendStates[3] = MaterialBlendState_t(false, false, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0x0);
         }
     }
     else
     {
         for (int i = 0; i < 2; ++i)
         {
-            MaterialDXState_t& dxState = matlAsset->dxStates[i];
+            MaterialDXState_v15_t& dxState = matlAsset->dxStates[i];
 
-            dxState.blendStates[0] = MaterialBlendState_t(true, D3D11_BLEND_ONE, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
-            dxState.blendStates[1] = MaterialBlendState_t(true, D3D11_BLEND_ONE, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
-            dxState.blendStates[2] = MaterialBlendState_t(true, D3D11_BLEND_ONE, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_OP_ADD, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, 0xF);
-            dxState.blendStates[3] = MaterialBlendState_t(true, D3D11_BLEND_ONE, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0x0);
+            dxState.blendStates[0] = MaterialBlendState_t(false, true, D3D11_BLEND_ONE, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
+            dxState.blendStates[1] = MaterialBlendState_t(false, true, D3D11_BLEND_ONE, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
+            dxState.blendStates[2] = MaterialBlendState_t(false, true, D3D11_BLEND_ONE, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_OP_ADD, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, 0xF);
+            dxState.blendStates[3] = MaterialBlendState_t(false, true, D3D11_BLEND_ONE, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0x0);
         }
     }
 

--- a/src/assets/shader.cpp
+++ b/src/assets/shader.cpp
@@ -1,74 +1,185 @@
 #include "pch.h"
 #include "assets.h"
 #include "public/shader.h"
+#include "public/multishader.h"
 #include "utils/dxutils.h"
+
+int ShaderV8_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::path& inputPath, CPakDataChunk& cpuDataChunk)
+{
+	CMultiShaderWrapperIO io = {};
+
+	CMultiShaderWrapperIO::ShaderFile_t file = {};
+	if (!io.ReadFile(inputPath.string().c_str(), &file))
+	{
+		Error("Failed to parse MSW file '%s'.\n", inputPath.string().c_str());
+		return -1;
+	}
+
+	const size_t numShaderBuffers = file.shader->entries.size();
+
+	ShaderAssetHeader_v8_t* hdr = reinterpret_cast<ShaderAssetHeader_v8_t*>(hdrChunk.Data());
+
+	// Set to invalid so we can update it when a buffer is found, and detect that it has been set.
+	hdr->type = eShaderType::Invalid;
+	hdr->unk_C = static_cast<int>(numShaderBuffers);
+
+	size_t totalShaderDataSize = 0;
+
+	for (auto& it : file.shader->entries)
+	{
+		if (it.buffer != nullptr)
+			totalShaderDataSize += IALIGN(it.size, 8);
+	}
+	assert(totalShaderDataSize != 0);
+
+	// Size of the data that describes each shader bytecode buffer
+	const size_t descriptorSize = numShaderBuffers * sizeof(ShaderByteCode_t);
+
+	const size_t shaderBufferChunkSize = descriptorSize + totalShaderDataSize;
+	cpuDataChunk = pak->CreateDataChunk(shaderBufferChunkSize, SF_CPU | SF_TEMP, 8);
+
+	ShaderByteCode_t* shaderBCDescriptors = reinterpret_cast<ShaderByteCode_t*>(cpuDataChunk.Data());
+
+	// Offset at which the next bytecode buffer will be written.
+	// Initially starts at the end of the descriptors and then gets increased every time a buffer is written.
+	size_t nextBytecodeBufferOffset = descriptorSize;
+	for (size_t i = 0; i < numShaderBuffers; ++i)
+	{
+		const CMultiShaderWrapperIO::ShaderEntry_t& entry = file.shader->entries[i];
+
+		ShaderByteCode_t* bc = &shaderBCDescriptors[i];
+
+		if (entry.buffer)
+		{
+			assert(entry.size > 0);
+
+			bc->data = cpuDataChunk.GetPointer(nextBytecodeBufferOffset);
+			bc->dataSize = entry.size;
+
+			// Register the data pointer at the 
+			pak->AddPointer(cpuDataChunk.GetPointer((i * sizeof(ShaderByteCode_t)) + offsetof(ShaderByteCode_t, data)));
+
+			memcpy_s(cpuDataChunk.Data() + nextBytecodeBufferOffset, entry.size, entry.buffer, entry.size);
+
+			nextBytecodeBufferOffset += IALIGN(entry.size, 8);
+
+			// If the shader type hasn't been found yet, parse this buffer and find out what we want to set it as.
+			if (hdr->type == eShaderType::Invalid)
+			{
+				ParsedDXShaderData_t parsedData;
+
+				if (DXUtils::GetParsedShaderData(entry.buffer, entry.size, &parsedData))
+				{
+					if (parsedData.foundFlags & SHDR_FOUND_RDEF)
+					{
+						hdr->type = static_cast<eShaderType>(parsedData.pakShaderType);
+					}
+				}
+			}
+		}
+		else
+		{
+			// Null shader
+			if (entry.refIndex == UINT16_MAX)
+			{
+				// technically, these shaders can actually have a pointer to an empty dx bytecode buffer (with no actual bytecode from what i can tell?)
+				// but the logic of the function that reads them should mean that the pointer is never accessed if entry.size is <= 0
+			}
+			else // Shader entry references another shader instead of defining its own buffer
+			{
+				bc->dataSize = ~entry.refIndex;
+			}
+		}
+
+	}
+
+	return static_cast<int>(file.shader->entries.size());
+}
 
 void Assets::AddShaderAsset_v8(CPakFile* pak, const char* assetPath, rapidjson::Value& mapEntry)
 {
 	Log("Adding shdr asset '%s'\n", assetPath);
 
-	CPakDataChunk hdrChunk = pak->CreateDataChunk(sizeof(ShaderAssetHeader_v8_t), SF_HEAD, 8);
-
-	const fs::path inputFilePath = pak->GetAssetPath() / fs::path(assetPath).replace_extension("fxc");
+	const fs::path inputFilePath = pak->GetAssetPath() / fs::path(assetPath).replace_extension("msw");
 
 	if (!fs::exists(inputFilePath))
 		Error("Failed to find compiled shader file for asset '%s' (%s).\n", assetPath, inputFilePath.string().c_str());
 
-	const fs::path pakFilePath = fs::path(assetPath).replace_extension("");
+	CPakDataChunk hdrChunk = pak->CreateDataChunk(sizeof(ShaderAssetHeader_v8_t), SF_HEAD, 8);
 
+	const fs::path pakFilePath = fs::path(assetPath).replace_extension(""); // Make sure the path has no extension, just in case.
 	CPakDataChunk nameChunk = pak->CreateDataChunk(pakFilePath.string().length() + 1, SF_CPU | SF_DEV, 1);
 	strcpy_s(nameChunk.Data(), nameChunk.GetSize(), pakFilePath.string().c_str());
 
 	ShaderAssetHeader_v8_t* hdr = reinterpret_cast<ShaderAssetHeader_v8_t*>(hdrChunk.Data());
 
+	hdr->name = nameChunk.GetPointer();
+
 	pak->AddPointer(hdrChunk.GetPointer(offsetof(ShaderAssetHeader_v8_t, name)));
+
+	CPakDataChunk dataChunk = {};
+	int numShaders = ShaderV8_CreateFromMSW(pak, hdrChunk, inputFilePath, dataChunk);
+
+	// Data chunk used by pointer "unk_10" and "shaderInputFlags"
+	// The first set of data in the buffer is reserved data for when the asset is loaded (equal to 16 bytes per shader entry)
+	// 
+	// The remainder of the data is used for the input layout flags of each shader.
+	// This data consists of 2 QWORDs per shader entry, with the first being set to the flags
+	// and the second being unknown.
+	const size_t inputFlagsDataSize = numShaders * (2 * sizeof(uint64_t));
+	const size_t reservedDataSize = numShaders * (16);
+	CPakDataChunk shaderInfoChunk = pak->CreateDataChunk(reservedDataSize + inputFlagsDataSize, SF_CPU, 1);
+
+	// Get a pointer to the beginning of the reserved data section
+	hdr->unk_10 = shaderInfoChunk.GetPointer();
+	// Get a pointer after the end of the reserved data section
+	hdr->shaderInputFlags = shaderInfoChunk.GetPointer(reservedDataSize);
+
+	// Register the pointers we have just written.
+	pak->AddPointer(hdrChunk.GetPointer(offsetof(ShaderAssetHeader_v8_t, unk_10)));
 	pak->AddPointer(hdrChunk.GetPointer(offsetof(ShaderAssetHeader_v8_t, shaderInputFlags)));
 
-	hdr->name = nameChunk.GetPointer();
-	hdr->type = GetShaderTypeByName(JSON_GET_STR(mapEntry, "shaderType", "invalid"));
-	hdr->unk_C = 1;
-
-	// File Data
-	const size_t inputFileSize = Utils::GetFileSize(inputFilePath.string());
-
-	CPakDataChunk bytecodeChunk = pak->CreateDataChunk(sizeof(ShaderByteCode_t) + inputFileSize, SF_CPU, 8);
-
-	ShaderByteCode_t* bytecodeHdr = reinterpret_cast<ShaderByteCode_t*>(bytecodeChunk.Data());
-
-	bytecodeHdr->data = bytecodeChunk.GetPointer(sizeof(ShaderByteCode_t));
-	bytecodeHdr->dataSize = static_cast<int>(inputFileSize);
-
-	std::ifstream inputFile(inputFilePath, std::ios::in | std::ios::binary);
-
-	char* bytecodeDest = bytecodeChunk.Data() + sizeof(ShaderByteCode_t);
-	inputFile.read(bytecodeDest, inputFileSize);
-
-	inputFile.close();
-
-	ParsedDXShaderData_t parsedData;
-
-	if (DXUtils::GetParsedShaderData(bytecodeDest, inputFileSize, &parsedData))
+	// get input layout flags from json
+	// this will eventually be taken from the bytecode itself, but that code will be very annoying so for now
+	// the values are manually provided
+	if (JSON_IS_ARRAY(mapEntry, "inputFlags") && mapEntry["inputFlags"].GetArray().Size() == static_cast<size_t>(numShaders))
 	{
-		if (parsedData.foundFlags & SHDR_FOUND_RDEF)
+		uint64_t* inputFlags = reinterpret_cast<uint64_t*>(shaderInfoChunk.Data() + reservedDataSize);
+
+		size_t i = 0;
+		for (auto& elem : mapEntry["inputFlags"].GetArray())
 		{
-			hdr->type = static_cast<eShaderType>(parsedData.pakShaderType);
+			uint64_t flag = 0;
+			if (elem.IsUint64())
+			{
+				flag = elem.GetUint64();
+			}
+			else if (elem.IsString())
+			{
+				flag = strtoull(elem.GetString(), NULL, 0);
+			}
+			else
+				Error("Found invalid input flag (idx %lld) for shader asset %s. Flag must be either an integer literal or a hex number as a string.\n", i, assetPath);
+
+
+			if (flag == 0)
+				Warning("Found potentially invalid input flag (idx %lld) for shader asset %s. Flag value is zero.\n", i, assetPath);
+
+			inputFlags[2 * i] = flag;
+
+			i++;
 		}
 	}
-	
-	// ============= Input Flags =============
-	// static size for now. this may need to become dynamic if someone ever actually uses
-	// a shader with more than one bytecode buffer
-	CPakDataChunk inputFlagChunk = pak->CreateDataChunk(8, SF_CPU, 1);
-	*reinterpret_cast<uint64_t*>(inputFlagChunk.Data()) = JSON_GET_UINT64(mapEntry, "inputFlags", 0);
+	else
+		Error("Invalid \"inputFlags\" field for shader asset %s. Must be an array with the same number of elements as there are shader buffers in the MSW file (%i).\n", assetPath, numShaders);
 
-	hdr->shaderInputFlags = inputFlagChunk.GetPointer();
 	// =======================================
 
 	PakAsset_t asset;
 	asset.InitAsset(
 		pakFilePath.string() + ".rpak",
 		hdrChunk.GetPointer(), hdrChunk.GetSize(),
-		bytecodeChunk.GetPointer(), UINT64_MAX, UINT64_MAX, AssetType::SHDR);
+		dataChunk.GetPointer(), UINT64_MAX, UINT64_MAX, AssetType::SHDR);
 	asset.SetHeaderPointer(hdrChunk.Data());
 
 	asset.version = 8;
@@ -83,15 +194,96 @@ void Assets::AddShaderAsset_v8(CPakFile* pak, const char* assetPath, rapidjson::
 	printf("\n");
 }
 
-int ShaderV12_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::path& inputPath)
+int ShaderV12_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::path& inputPath, CPakDataChunk& cpuDataChunk)
 {
-	UNUSED(pak);
-	UNUSED(hdrChunk);
-	UNUSED(inputPath);
-	//ShaderAssetHeader_v12_t* hdr = reinterpret_cast<ShaderAssetHeader_v12_t*>(hdrChunk.Data());
+	CMultiShaderWrapperIO io = {};
+	
+	CMultiShaderWrapperIO::ShaderFile_t file = {};
+	if (!io.ReadFile(inputPath.string().c_str(), &file))
+	{
+		Error("Failed to parse MSW file '%s'.\n", inputPath.string().c_str());
+		return -1;
+	}
 
+	ShaderAssetHeader_v12_t* hdr = reinterpret_cast<ShaderAssetHeader_v12_t*>(hdrChunk.Data());
 
-	return -1;
+	// Set to invalid so we can update it when a buffer is found, and detect that it has been set.
+	hdr->type = eShaderType::Invalid;
+	memcpy_s(hdr->shaderFeatures, sizeof(hdr->shaderFeatures), file.shader->features, sizeof(file.shader->features));
+
+	const size_t numShaderBuffers = file.shader->entries.size();
+
+	size_t totalShaderDataSize = 0;
+
+	for (auto& it : file.shader->entries)
+	{
+		if(it.buffer != nullptr)
+			totalShaderDataSize += IALIGN(it.size, 8);
+	}
+	assert(totalShaderDataSize != 0);
+
+	// Size of the data that describes each shader bytecode buffer
+	const size_t descriptorSize = numShaderBuffers * sizeof(ShaderByteCode_t);
+
+	const size_t shaderBufferChunkSize = descriptorSize + totalShaderDataSize;
+	cpuDataChunk = pak->CreateDataChunk(shaderBufferChunkSize, SF_CPU | SF_TEMP, 8);
+
+	ShaderByteCode_t* shaderBCDescriptors = reinterpret_cast<ShaderByteCode_t*>(cpuDataChunk.Data());
+
+	// Offset at which the next bytecode buffer will be written.
+	// Initially starts at the end of the descriptors and then gets increased every time a buffer is written.
+	size_t nextBytecodeBufferOffset = descriptorSize;
+	for (size_t i = 0; i < numShaderBuffers; ++i)
+	{
+		const CMultiShaderWrapperIO::ShaderEntry_t& entry = file.shader->entries[i];
+
+		ShaderByteCode_t* bc = &shaderBCDescriptors[i];
+
+		if (entry.buffer)
+		{
+			assert(entry.size > 0);
+
+			bc->data = cpuDataChunk.GetPointer(nextBytecodeBufferOffset);
+			bc->dataSize = entry.size;
+
+			// Register the data pointer at the 
+			pak->AddPointer(cpuDataChunk.GetPointer( (i * sizeof(ShaderByteCode_t)) + offsetof(ShaderByteCode_t, data) ));
+
+			memcpy_s(cpuDataChunk.Data() + nextBytecodeBufferOffset, entry.size, entry.buffer, entry.size);
+
+			nextBytecodeBufferOffset += IALIGN(entry.size, 8);
+
+			// If the shader type hasn't been found yet, parse this buffer and find out what we want to set it as.
+			if (hdr->type == eShaderType::Invalid)
+			{
+				ParsedDXShaderData_t parsedData;
+
+				if (DXUtils::GetParsedShaderData(entry.buffer, entry.size, &parsedData))
+				{
+					if (parsedData.foundFlags & SHDR_FOUND_RDEF)
+					{
+						hdr->type = static_cast<eShaderType>(parsedData.pakShaderType);
+					}
+				}
+			}
+		}
+		else
+		{
+			// Null shader
+			if (entry.refIndex == UINT16_MAX)
+			{
+				// technically, these shaders can actually have a pointer to an empty dx bytecode buffer (with no actual bytecode from what i can tell?)
+				// but the logic of the function that reads them should mean that the pointer is never accessed if entry.size is <= 0
+			}
+			else // Shader entry references another shader instead of defining its own buffer
+			{
+				bc->dataSize = ~entry.refIndex;
+			}
+		}
+		
+	}
+
+	return static_cast<int>(file.shader->entries.size());
 }
 
 void Assets::AddShaderAsset_v12(CPakFile* pak, const char* assetPath, rapidjson::Value& mapEntry)
@@ -109,51 +301,75 @@ void Assets::AddShaderAsset_v12(CPakFile* pak, const char* assetPath, rapidjson:
 	CPakDataChunk nameChunk = pak->CreateDataChunk(pakFilePath.string().length() + 1, SF_CPU | SF_DEV, 1);
 	strcpy_s(nameChunk.Data(), nameChunk.GetSize(), pakFilePath.string().c_str());
 
-
 	ShaderAssetHeader_v12_t* hdr = reinterpret_cast<ShaderAssetHeader_v12_t*>(hdrChunk.Data());
 
+	hdr->name = nameChunk.GetPointer();
+
 	pak->AddPointer(hdrChunk.GetPointer(offsetof(ShaderAssetHeader_v12_t, name)));
+
+	CPakDataChunk dataChunk = {};
+	int numShaders = ShaderV12_CreateFromMSW(pak, hdrChunk, inputFilePath, dataChunk);
+
+	// Data chunk used by pointer "unk_10" and "shaderInputFlags"
+	// The first set of data in the buffer is reserved data for when the asset is loaded (equal to 16 bytes per shader entry)
+	// 
+	// The remainder of the data is used for the input layout flags of each shader.
+	// This data consists of 2 QWORDs per shader entry, with the first being set to the flags
+	// and the second being unknown.
+	const size_t inputFlagsDataSize = numShaders * (2 * sizeof(uint64_t));
+	const size_t reservedDataSize   = numShaders * (16);
+	CPakDataChunk shaderInfoChunk = pak->CreateDataChunk(reservedDataSize + inputFlagsDataSize, SF_CPU, 1);
+
+	// Get a pointer to the beginning of the reserved data section
+	hdr->unk_10 = shaderInfoChunk.GetPointer();
+	// Get a pointer after the end of the reserved data section
+	hdr->shaderInputFlags = shaderInfoChunk.GetPointer(reservedDataSize);
+
+	// Register the pointers we have just written.
+	pak->AddPointer(hdrChunk.GetPointer(offsetof(ShaderAssetHeader_v12_t, unk_10)));
 	pak->AddPointer(hdrChunk.GetPointer(offsetof(ShaderAssetHeader_v12_t, shaderInputFlags)));
 
-	hdr->name = nameChunk.GetPointer();
-	//hdr->type = GetShaderTypeByName(JSON_GET_STR(mapEntry, "shaderType", "invalid"));
-	//hdr->unk_C = 1;
+	// get input layout flags from json
+	// this will eventually be taken from the bytecode itself, but that code will be very annoying so for now
+	// the values are manually provided
+	if (JSON_IS_ARRAY(mapEntry, "inputFlags") && mapEntry["inputFlags"].GetArray().Size() == static_cast<size_t>(numShaders))
+	{
+		uint64_t* inputFlags = reinterpret_cast<uint64_t*>(shaderInfoChunk.Data() + reservedDataSize);
 
-	int numShaders = ShaderV12_CreateFromMSW(pak, hdrChunk, inputFilePath);
-	UNUSED(numShaders);
+		size_t i = 0;
+		for (auto& elem : mapEntry["inputFlags"].GetArray())
+		{
+			uint64_t flag = 0;
+			if (elem.IsUint64())
+			{
+				flag = elem.GetUint64();
+			}
+			else if (elem.IsString())
+			{
+				flag = strtoull(elem.GetString(), NULL, 0);
+			}
+			else
+				Error("Found invalid input flag (idx %lld) for shader asset %s. Flag must be either an integer literal or a hex number as a string.\n", i, assetPath);
 
 
-	// File Data
-	const size_t inputFileSize = Utils::GetFileSize(inputFilePath.string());
+			if (flag == 0)
+				Warning("Found potentially invalid input flag (idx %lld) for shader asset %s. Flag value is zero.\n", i, assetPath);
 
-	CPakDataChunk bytecodeChunk = pak->CreateDataChunk(sizeof(ShaderByteCode_t) + inputFileSize, SF_CPU, 8);
+			inputFlags[2 * i] = flag;
 
-	ShaderByteCode_t* bytecodeHdr = reinterpret_cast<ShaderByteCode_t*>(bytecodeChunk.Data());
+			i++;
+		}
+	}
+	else
+		Error("Invalid \"inputFlags\" field for shader asset %s. Must be an array with the same number of elements as there are shader buffers in the MSW file (%i).\n", assetPath, numShaders);
 
-	bytecodeHdr->data = bytecodeChunk.GetPointer(sizeof(ShaderByteCode_t));
-	bytecodeHdr->dataSize = static_cast<int>(inputFileSize);
-
-	std::ifstream inputFile(inputFilePath, std::ios::in | std::ios::binary);
-
-	char* bytecodeDest = bytecodeChunk.Data() + sizeof(ShaderByteCode_t);
-	inputFile.read(bytecodeDest, inputFileSize);
-
-	inputFile.close();
-
-	// ============= Input Flags =============
-	// static size for now. this may need to become dynamic if someone ever actually uses
-	// a shader with more than one bytecode buffer
-	CPakDataChunk inputFlagChunk = pak->CreateDataChunk(8, SF_CPU, 1);
-	*reinterpret_cast<uint64_t*>(inputFlagChunk.Data()) = JSON_GET_UINT64(mapEntry, "inputFlags", 0);
-
-	hdr->shaderInputFlags = inputFlagChunk.GetPointer();
 	// =======================================
 
 	PakAsset_t asset;
 	asset.InitAsset(
 		pakFilePath.string() + ".rpak",
 		hdrChunk.GetPointer(), hdrChunk.GetSize(),
-		bytecodeChunk.GetPointer(), UINT64_MAX, UINT64_MAX, AssetType::SHDR);
+		dataChunk.GetPointer(), UINT64_MAX, UINT64_MAX, AssetType::SHDR);
 	asset.SetHeaderPointer(hdrChunk.Data());
 
 	asset.version = 12;

--- a/src/assets/shader.cpp
+++ b/src/assets/shader.cpp
@@ -44,7 +44,7 @@ int ShaderV8_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::pat
 	}
 	assert(totalShaderDataSize != 0);
 
-	const int8_t entrySize = hdr->type == eShaderType::Vertex ? 24 : sizeof(ShaderByteCode_t);
+	const int8_t entrySize = hdr->type == eShaderType::Vertex ? 24 : 16;
 
 	// Size of the data that describes each shader bytecode buffer
 	const size_t descriptorSize = numShaderBuffers * entrySize;
@@ -67,6 +67,14 @@ int ShaderV8_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::pat
 
 			bc->data = cpuDataChunk.GetPointer(nextBytecodeBufferOffset);
 			bc->dataSize = entry.size;
+
+			if (hdr->type == eShaderType::Vertex)
+			{
+				bc->inputSignatureBlob = bc->data;
+				bc->unk = bc->dataSize;
+
+				pak->AddPointer(cpuDataChunk.GetPointer((i * entrySize) + offsetof(ShaderByteCode_t, inputSignatureBlob)));
+			}
 
 			// Register the data pointer at the 
 			pak->AddPointer(cpuDataChunk.GetPointer((i * entrySize) + offsetof(ShaderByteCode_t, data)));
@@ -234,7 +242,7 @@ int ShaderV12_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::pa
 	}
 	assert(totalShaderDataSize != 0);
 
-	const int8_t entrySize = hdr->type == eShaderType::Vertex ? 24 : sizeof(ShaderByteCode_t);
+	const int8_t entrySize = hdr->type == eShaderType::Vertex ? 24 : 16;
 
 	// Size of the data that describes each shader bytecode buffer
 	const size_t descriptorSize = numShaderBuffers * entrySize;
@@ -257,6 +265,14 @@ int ShaderV12_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::pa
 
 			bc->data = cpuDataChunk.GetPointer(nextBytecodeBufferOffset);
 			bc->dataSize = entry.size;
+
+			if (hdr->type == eShaderType::Vertex)
+			{
+				bc->inputSignatureBlob = bc->data;
+				bc->unk = bc->dataSize;
+
+				pak->AddPointer(cpuDataChunk.GetPointer((i * entrySize) + offsetof(ShaderByteCode_t, inputSignatureBlob)));
+			}
 
 			// Register the data pointer at the 
 			pak->AddPointer(cpuDataChunk.GetPointer( (i * entrySize) + offsetof(ShaderByteCode_t, data) ));

--- a/src/assets/shader.cpp
+++ b/src/assets/shader.cpp
@@ -393,11 +393,11 @@ void Assets::AddShaderAsset_v12(CPakFile* pak, const char* assetPath, rapidjson:
 
 	if (JSON_IS_UINT64(mapEntry, "$guid"))
 	{
-		assetGuid = JSON_GET_UINT64(mapEntry, "guid", 0);
+		assetGuid = JSON_GET_UINT64(mapEntry, "$guid", 0);
 	}
 	else if (JSON_IS_STR(mapEntry, "$guid"))
 	{
-		RTech::ParseGUIDFromString(JSON_GET_STR(mapEntry, "guid", ""), &assetGuid);
+		RTech::ParseGUIDFromString(JSON_GET_STR(mapEntry, "$guid", ""), &assetGuid);
 	}
 	else
 	{

--- a/src/assets/shader.cpp
+++ b/src/assets/shader.cpp
@@ -149,7 +149,8 @@ void Assets::AddShaderAsset_v8(CPakFile* pak, const char* assetPath, rapidjson::
 	// get input layout flags from json
 	// this will eventually be taken from the bytecode itself, but that code will be very annoying so for now
 	// the values are manually provided
-	if (JSON_IS_ARRAY(mapEntry, "inputFlags") && mapEntry["inputFlags"].GetArray().Size() == static_cast<size_t>(numShaders))
+	// size check is temporarily disabled while vertex shader differences are investigated
+	if (JSON_IS_ARRAY(mapEntry, "inputFlags") /*&& mapEntry["inputFlags"].GetArray().Size() == static_cast<size_t>(numShaders)*/)
 	{
 		uint64_t* inputFlags = reinterpret_cast<uint64_t*>(shaderInfoChunk.Data() + reservedDataSize);
 
@@ -172,7 +173,11 @@ void Assets::AddShaderAsset_v8(CPakFile* pak, const char* assetPath, rapidjson::
 			if (flag == 0)
 				Warning("Found potentially invalid input flag (idx %lld) for shader asset %s. Flag value is zero.\n", i, assetPath);
 
-			inputFlags[2 * i] = flag;
+			// vertex shaders seem to have data every 8 bytes, unlike (seemingly) every other shader that only uses 8 out of every 16 bytes
+			if(hdr->type == eShaderType::Vertex)
+				inputFlags[i] = flag;
+			else
+				inputFlags[2 * i] = flag;
 
 			i++;
 		}

--- a/src/assets/shader.cpp
+++ b/src/assets/shader.cpp
@@ -82,3 +82,88 @@ void Assets::AddShaderAsset_v8(CPakFile* pak, const char* assetPath, rapidjson::
 
 	printf("\n");
 }
+
+int ShaderV12_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::path& inputPath)
+{
+	UNUSED(pak);
+	UNUSED(hdrChunk);
+	UNUSED(inputPath);
+	//ShaderAssetHeader_v12_t* hdr = reinterpret_cast<ShaderAssetHeader_v12_t*>(hdrChunk.Data());
+
+
+	return -1;
+}
+
+void Assets::AddShaderAsset_v12(CPakFile* pak, const char* assetPath, rapidjson::Value& mapEntry)
+{
+	Log("Adding shdr asset '%s'\n", assetPath);
+
+	const fs::path inputFilePath = pak->GetAssetPath() / fs::path(assetPath).replace_extension("msw");
+
+	if (!fs::exists(inputFilePath))
+		Error("Failed to find compiled shader file for asset '%s' (%s).\n", assetPath, inputFilePath.string().c_str());
+
+	CPakDataChunk hdrChunk = pak->CreateDataChunk(sizeof(ShaderAssetHeader_v12_t), SF_HEAD, 8);
+
+	const fs::path pakFilePath = fs::path(assetPath).replace_extension(""); // Make sure the path has no extension, just in case.
+	CPakDataChunk nameChunk = pak->CreateDataChunk(pakFilePath.string().length() + 1, SF_CPU | SF_DEV, 1);
+	strcpy_s(nameChunk.Data(), nameChunk.GetSize(), pakFilePath.string().c_str());
+
+
+	ShaderAssetHeader_v12_t* hdr = reinterpret_cast<ShaderAssetHeader_v12_t*>(hdrChunk.Data());
+
+	pak->AddPointer(hdrChunk.GetPointer(offsetof(ShaderAssetHeader_v12_t, name)));
+	pak->AddPointer(hdrChunk.GetPointer(offsetof(ShaderAssetHeader_v12_t, shaderInputFlags)));
+
+	hdr->name = nameChunk.GetPointer();
+	//hdr->type = GetShaderTypeByName(JSON_GET_STR(mapEntry, "shaderType", "invalid"));
+	//hdr->unk_C = 1;
+
+	int numShaders = ShaderV12_CreateFromMSW(pak, hdrChunk, inputFilePath);
+	UNUSED(numShaders);
+
+
+	// File Data
+	const size_t inputFileSize = Utils::GetFileSize(inputFilePath.string());
+
+	CPakDataChunk bytecodeChunk = pak->CreateDataChunk(sizeof(ShaderByteCode_t) + inputFileSize, SF_CPU, 8);
+
+	ShaderByteCode_t* bytecodeHdr = reinterpret_cast<ShaderByteCode_t*>(bytecodeChunk.Data());
+
+	bytecodeHdr->data = bytecodeChunk.GetPointer(sizeof(ShaderByteCode_t));
+	bytecodeHdr->dataSize = static_cast<int>(inputFileSize);
+
+	std::ifstream inputFile(inputFilePath, std::ios::in | std::ios::binary);
+
+	char* bytecodeDest = bytecodeChunk.Data() + sizeof(ShaderByteCode_t);
+	inputFile.read(bytecodeDest, inputFileSize);
+
+	inputFile.close();
+
+	// ============= Input Flags =============
+	// static size for now. this may need to become dynamic if someone ever actually uses
+	// a shader with more than one bytecode buffer
+	CPakDataChunk inputFlagChunk = pak->CreateDataChunk(8, SF_CPU, 1);
+	*reinterpret_cast<uint64_t*>(inputFlagChunk.Data()) = JSON_GET_UINT64(mapEntry, "inputFlags", 0);
+
+	hdr->shaderInputFlags = inputFlagChunk.GetPointer();
+	// =======================================
+
+	PakAsset_t asset;
+	asset.InitAsset(
+		pakFilePath.string() + ".rpak",
+		hdrChunk.GetPointer(), hdrChunk.GetSize(),
+		bytecodeChunk.GetPointer(), UINT64_MAX, UINT64_MAX, AssetType::SHDR);
+	asset.SetHeaderPointer(hdrChunk.Data());
+
+	asset.version = 12;
+
+	asset.pageEnd = pak->GetNumPages();
+
+	// this doesnt account for external dependencies atm
+	asset.remainingDependencyCount = 1;
+
+	pak->PushAsset(asset);
+
+	printf("\n");
+}

--- a/src/assets/shader.cpp
+++ b/src/assets/shader.cpp
@@ -29,11 +29,25 @@ int ShaderV8_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::pat
 	{
 		if (it.buffer != nullptr)
 			totalShaderDataSize += IALIGN(it.size, 8);
+
+		// If the shader type hasn't been found yet, parse this buffer and find out what we want to set it as.
+		if (hdr->type == eShaderType::Invalid)
+		{
+			if (DXUtils::GetParsedShaderData(it.buffer, it.size, firstShaderData))
+			{
+				if (firstShaderData->foundFlags & SHDR_FOUND_RDEF)
+				{
+					hdr->type = static_cast<eShaderType>(firstShaderData->pakShaderType);
+				}
+			}
+		}
 	}
 	assert(totalShaderDataSize != 0);
 
+	const int8_t entrySize = hdr->type == eShaderType::Vertex ? 24 : sizeof(ShaderByteCode_t);
+
 	// Size of the data that describes each shader bytecode buffer
-	const size_t descriptorSize = numShaderBuffers * sizeof(ShaderByteCode_t);
+	const size_t descriptorSize = numShaderBuffers * entrySize;
 
 	const size_t shaderBufferChunkSize = descriptorSize + totalShaderDataSize;
 	cpuDataChunk = pak->CreateDataChunk(shaderBufferChunkSize, SF_CPU | SF_TEMP, 8);
@@ -57,23 +71,13 @@ int ShaderV8_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::pat
 			bc->dataSize = entry.size;
 
 			// Register the data pointer at the 
-			pak->AddPointer(cpuDataChunk.GetPointer((i * sizeof(ShaderByteCode_t)) + offsetof(ShaderByteCode_t, data)));
+			pak->AddPointer(cpuDataChunk.GetPointer((i * entrySize) + offsetof(ShaderByteCode_t, data)));
 
 			memcpy_s(cpuDataChunk.Data() + nextBytecodeBufferOffset, entry.size, entry.buffer, entry.size);
 
 			nextBytecodeBufferOffset += IALIGN(entry.size, 8);
 
-			// If the shader type hasn't been found yet, parse this buffer and find out what we want to set it as.
-			if (hdr->type == eShaderType::Invalid)
-			{
-				if (DXUtils::GetParsedShaderData(entry.buffer, entry.size, firstShaderData))
-				{
-					if (firstShaderData->foundFlags & SHDR_FOUND_RDEF)
-					{
-						hdr->type = static_cast<eShaderType>(firstShaderData->pakShaderType);
-					}
-				}
-			}
+
 		}
 		else
 		{
@@ -219,11 +223,25 @@ int ShaderV12_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::pa
 	{
 		if(it.buffer != nullptr)
 			totalShaderDataSize += IALIGN(it.size, 8);
+
+		// If the shader type hasn't been found yet, parse this buffer and find out what we want to set it as.
+		if (hdr->type == eShaderType::Invalid)
+		{
+			if (DXUtils::GetParsedShaderData(it.buffer, it.size, firstShaderData))
+			{
+				if (firstShaderData->foundFlags & SHDR_FOUND_RDEF)
+				{
+					hdr->type = static_cast<eShaderType>(firstShaderData->pakShaderType);
+				}
+			}
+		}
 	}
 	assert(totalShaderDataSize != 0);
 
+	const int8_t entrySize = hdr->type == eShaderType::Vertex ? 24 : sizeof(ShaderByteCode_t);
+
 	// Size of the data that describes each shader bytecode buffer
-	const size_t descriptorSize = numShaderBuffers * sizeof(ShaderByteCode_t);
+	const size_t descriptorSize = numShaderBuffers * entrySize;
 
 	const size_t shaderBufferChunkSize = descriptorSize + totalShaderDataSize;
 	cpuDataChunk = pak->CreateDataChunk(shaderBufferChunkSize, SF_CPU | SF_TEMP, 8);
@@ -247,23 +265,11 @@ int ShaderV12_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::pa
 			bc->dataSize = entry.size;
 
 			// Register the data pointer at the 
-			pak->AddPointer(cpuDataChunk.GetPointer( (i * sizeof(ShaderByteCode_t)) + offsetof(ShaderByteCode_t, data) ));
+			pak->AddPointer(cpuDataChunk.GetPointer( (i * entrySize) + offsetof(ShaderByteCode_t, data) ));
 
 			memcpy_s(cpuDataChunk.Data() + nextBytecodeBufferOffset, entry.size, entry.buffer, entry.size);
 
 			nextBytecodeBufferOffset += IALIGN(entry.size, 8);
-
-			// If the shader type hasn't been found yet, parse this buffer and find out what we want to set it as.
-			if (hdr->type == eShaderType::Invalid)
-			{
-				if (DXUtils::GetParsedShaderData(entry.buffer, entry.size, firstShaderData))
-				{
-					if (firstShaderData->foundFlags & SHDR_FOUND_RDEF)
-					{
-						hdr->type = static_cast<eShaderType>(firstShaderData->pakShaderType);
-					}
-				}
-			}
 		}
 		else
 		{

--- a/src/assets/shader.cpp
+++ b/src/assets/shader.cpp
@@ -4,7 +4,7 @@
 #include "public/multishader.h"
 #include "utils/dxutils.h"
 
-int ShaderV8_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::path& inputPath, CPakDataChunk& cpuDataChunk)
+int ShaderV8_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::path& inputPath, CPakDataChunk& cpuDataChunk, ParsedDXShaderData_t* firstShaderData)
 {
 	CMultiShaderWrapperIO io = {};
 
@@ -66,13 +66,11 @@ int ShaderV8_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::pat
 			// If the shader type hasn't been found yet, parse this buffer and find out what we want to set it as.
 			if (hdr->type == eShaderType::Invalid)
 			{
-				ParsedDXShaderData_t parsedData;
-
-				if (DXUtils::GetParsedShaderData(entry.buffer, entry.size, &parsedData))
+				if (DXUtils::GetParsedShaderData(entry.buffer, entry.size, firstShaderData))
 				{
-					if (parsedData.foundFlags & SHDR_FOUND_RDEF)
+					if (firstShaderData->foundFlags & SHDR_FOUND_RDEF)
 					{
-						hdr->type = static_cast<eShaderType>(parsedData.pakShaderType);
+						hdr->type = static_cast<eShaderType>(firstShaderData->pakShaderType);
 					}
 				}
 			}
@@ -118,7 +116,8 @@ void Assets::AddShaderAsset_v8(CPakFile* pak, const char* assetPath, rapidjson::
 	pak->AddPointer(hdrChunk.GetPointer(offsetof(ShaderAssetHeader_v8_t, name)));
 
 	CPakDataChunk dataChunk = {};
-	int numShaders = ShaderV8_CreateFromMSW(pak, hdrChunk, inputFilePath, dataChunk);
+	ParsedDXShaderData_t* shaderData = new ParsedDXShaderData_t;
+	int numShaders = ShaderV8_CreateFromMSW(pak, hdrChunk, inputFilePath, dataChunk, shaderData);
 
 	// Data chunk used by pointer "unk_10" and "shaderInputFlags"
 	// The first set of data in the buffer is reserved data for when the asset is loaded (equal to 16 bytes per shader entry)
@@ -183,6 +182,7 @@ void Assets::AddShaderAsset_v8(CPakFile* pak, const char* assetPath, rapidjson::
 	asset.SetHeaderPointer(hdrChunk.Data());
 
 	asset.version = 8;
+	asset.SetPublicData(shaderData);
 
 	asset.pageEnd = pak->GetNumPages();
 
@@ -194,7 +194,7 @@ void Assets::AddShaderAsset_v8(CPakFile* pak, const char* assetPath, rapidjson::
 	printf("\n");
 }
 
-int ShaderV12_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::path& inputPath, CPakDataChunk& cpuDataChunk)
+int ShaderV12_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::path& inputPath, CPakDataChunk& cpuDataChunk, ParsedDXShaderData_t* firstShaderData)
 {
 	CMultiShaderWrapperIO io = {};
 	
@@ -256,13 +256,11 @@ int ShaderV12_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::pa
 			// If the shader type hasn't been found yet, parse this buffer and find out what we want to set it as.
 			if (hdr->type == eShaderType::Invalid)
 			{
-				ParsedDXShaderData_t parsedData;
-
-				if (DXUtils::GetParsedShaderData(entry.buffer, entry.size, &parsedData))
+				if (DXUtils::GetParsedShaderData(entry.buffer, entry.size, firstShaderData))
 				{
-					if (parsedData.foundFlags & SHDR_FOUND_RDEF)
+					if (firstShaderData->foundFlags & SHDR_FOUND_RDEF)
 					{
-						hdr->type = static_cast<eShaderType>(parsedData.pakShaderType);
+						hdr->type = static_cast<eShaderType>(firstShaderData->pakShaderType);
 					}
 				}
 			}
@@ -308,7 +306,8 @@ void Assets::AddShaderAsset_v12(CPakFile* pak, const char* assetPath, rapidjson:
 	pak->AddPointer(hdrChunk.GetPointer(offsetof(ShaderAssetHeader_v12_t, name)));
 
 	CPakDataChunk dataChunk = {};
-	int numShaders = ShaderV12_CreateFromMSW(pak, hdrChunk, inputFilePath, dataChunk);
+	ParsedDXShaderData_t* shaderData = new ParsedDXShaderData_t;
+	int numShaders = ShaderV12_CreateFromMSW(pak, hdrChunk, inputFilePath, dataChunk, shaderData);
 
 	// Data chunk used by pointer "unk_10" and "shaderInputFlags"
 	// The first set of data in the buffer is reserved data for when the asset is loaded (equal to 16 bytes per shader entry)
@@ -373,6 +372,7 @@ void Assets::AddShaderAsset_v12(CPakFile* pak, const char* assetPath, rapidjson:
 	asset.SetHeaderPointer(hdrChunk.Data());
 
 	asset.version = 12;
+	asset.SetPublicData(shaderData);
 
 	asset.pageEnd = pak->GetNumPages();
 

--- a/src/assets/shader.cpp
+++ b/src/assets/shader.cpp
@@ -52,8 +52,6 @@ int ShaderV8_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::pat
 	const size_t shaderBufferChunkSize = descriptorSize + totalShaderDataSize;
 	cpuDataChunk = pak->CreateDataChunk(shaderBufferChunkSize, SF_CPU | SF_TEMP, 8);
 
-	ShaderByteCode_t* shaderBCDescriptors = reinterpret_cast<ShaderByteCode_t*>(cpuDataChunk.Data());
-
 	// Offset at which the next bytecode buffer will be written.
 	// Initially starts at the end of the descriptors and then gets increased every time a buffer is written.
 	size_t nextBytecodeBufferOffset = descriptorSize;
@@ -61,7 +59,7 @@ int ShaderV8_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::pat
 	{
 		const CMultiShaderWrapperIO::ShaderEntry_t& entry = file.shader->entries[i];
 
-		ShaderByteCode_t* bc = &shaderBCDescriptors[i];
+		ShaderByteCode_t* bc = reinterpret_cast<ShaderByteCode_t*>(cpuDataChunk.Data() + (i * entrySize));
 
 		if (entry.buffer)
 		{
@@ -76,8 +74,6 @@ int ShaderV8_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::pat
 			memcpy_s(cpuDataChunk.Data() + nextBytecodeBufferOffset, entry.size, entry.buffer, entry.size);
 
 			nextBytecodeBufferOffset += IALIGN(entry.size, 8);
-
-
 		}
 		else
 		{
@@ -246,8 +242,6 @@ int ShaderV12_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::pa
 	const size_t shaderBufferChunkSize = descriptorSize + totalShaderDataSize;
 	cpuDataChunk = pak->CreateDataChunk(shaderBufferChunkSize, SF_CPU | SF_TEMP, 8);
 
-	ShaderByteCode_t* shaderBCDescriptors = reinterpret_cast<ShaderByteCode_t*>(cpuDataChunk.Data());
-
 	// Offset at which the next bytecode buffer will be written.
 	// Initially starts at the end of the descriptors and then gets increased every time a buffer is written.
 	size_t nextBytecodeBufferOffset = descriptorSize;
@@ -255,7 +249,7 @@ int ShaderV12_CreateFromMSW(CPakFile* pak, CPakDataChunk& hdrChunk, const fs::pa
 	{
 		const CMultiShaderWrapperIO::ShaderEntry_t& entry = file.shader->entries[i];
 
-		ShaderByteCode_t* bc = &shaderBCDescriptors[i];
+		ShaderByteCode_t* bc = reinterpret_cast<ShaderByteCode_t*>(cpuDataChunk.Data() + (i * entrySize));
 
 		if (entry.buffer)
 		{

--- a/src/assets/shader.cpp
+++ b/src/assets/shader.cpp
@@ -388,9 +388,28 @@ void Assets::AddShaderAsset_v12(CPakFile* pak, const char* assetPath, rapidjson:
 
 	// =======================================
 
+
+	uint64_t assetGuid = 0;
+
+	if (JSON_IS_UINT64(mapEntry, "$guid"))
+	{
+		assetGuid = JSON_GET_UINT64(mapEntry, "guid", 0);
+	}
+	else if (JSON_IS_STR(mapEntry, "$guid"))
+	{
+		RTech::ParseGUIDFromString(JSON_GET_STR(mapEntry, "guid", ""), &assetGuid);
+	}
+	else
+	{
+		assetGuid = RTech::StringToGuid((pakFilePath.string() + ".rpak").c_str());
+	}
+
+	if (assetGuid == 0)
+		Error("Invalid GUID provided for asset '%s'.\n", assetPath);
+
 	PakAsset_t asset;
 	asset.InitAsset(
-		pakFilePath.string() + ".rpak",
+		assetGuid,
 		hdrChunk.GetPointer(), hdrChunk.GetSize(),
 		dataChunk.GetPointer(), UINT64_MAX, UINT64_MAX, AssetType::SHDR);
 	asset.SetHeaderPointer(hdrChunk.Data());

--- a/src/assets/shaderset.cpp
+++ b/src/assets/shaderset.cpp
@@ -118,6 +118,8 @@ void Assets::AddShaderSetAsset_v8(CPakFile* pak, const char* assetPath, rapidjso
 	// this doesnt account for external dependencies atm
 	asset.remainingDependencyCount = static_cast<short>(guids.size() + 1);
 
+	asset.AddGuids(&guids);
+
 	pak->PushAsset(asset);
 
 	printf("\n");
@@ -232,6 +234,8 @@ void Assets::AddShaderSetAsset_v11(CPakFile* pak, const char* assetPath, rapidjs
 
 	// this doesnt account for external dependencies atm
 	asset.remainingDependencyCount = static_cast<short>(guids.size() + 1);
+
+	asset.AddGuids(&guids);
 
 	pak->PushAsset(asset);
 

--- a/src/assets/shaderset.cpp
+++ b/src/assets/shaderset.cpp
@@ -108,11 +108,11 @@ void Assets::AddShaderSetAsset_v8(CPakFile* pak, const char* assetPath, rapidjso
 
 	if (JSON_IS_UINT64(mapEntry, "$guid"))
 	{
-		assetGuid = JSON_GET_UINT64(mapEntry, "guid", 0);
+		assetGuid = JSON_GET_UINT64(mapEntry, "$guid", 0);
 	}
 	else if (JSON_IS_STR(mapEntry, "$guid"))
 	{
-		RTech::ParseGUIDFromString(JSON_GET_STR(mapEntry, "guid", ""), &assetGuid);
+		RTech::ParseGUIDFromString(JSON_GET_STR(mapEntry, "$guid", ""), &assetGuid);
 	}
 	else
 	{
@@ -243,11 +243,11 @@ void Assets::AddShaderSetAsset_v11(CPakFile* pak, const char* assetPath, rapidjs
 
 	if (JSON_IS_UINT64(mapEntry, "$guid"))
 	{
-		assetGuid = JSON_GET_UINT64(mapEntry, "guid", 0);
+		assetGuid = JSON_GET_UINT64(mapEntry, "$guid", 0);
 	}
 	else if(JSON_IS_STR(mapEntry, "$guid"))
 	{
-		RTech::ParseGUIDFromString(JSON_GET_STR(mapEntry, "guid", ""), &assetGuid);
+		RTech::ParseGUIDFromString(JSON_GET_STR(mapEntry, "$guid", ""), &assetGuid);
 	}
 	else
 	{

--- a/src/assets/shaderset.cpp
+++ b/src/assets/shaderset.cpp
@@ -103,10 +103,28 @@ void Assets::AddShaderSetAsset_v8(CPakFile* pak, const char* assetPath, rapidjso
 
 	if (hdr->numResources != 0)
 		Warning("Shader set '%s' has requested a non-zero number of shader resources. This feature is only intended for use on UI shaders, and may result in unexpected crashes or errors when used with incompatible shader code.\n", assetPath);
+	
+	uint64_t assetGuid = 0;
+
+	if (JSON_IS_UINT64(mapEntry, "$guid"))
+	{
+		assetGuid = JSON_GET_UINT64(mapEntry, "guid", 0);
+	}
+	else if (JSON_IS_STR(mapEntry, "$guid"))
+	{
+		RTech::ParseGUIDFromString(JSON_GET_STR(mapEntry, "guid", ""), &assetGuid);
+	}
+	else
+	{
+		assetGuid = RTech::StringToGuid((assetPathWithoutExtension + ".rpak").c_str());
+	}
+
+	if (assetGuid == 0)
+		Error("Invalid GUID provided for asset '%s'.\n", assetPath);
 
 	PakAsset_t asset;
 	asset.InitAsset(
-		assetPathWithoutExtension + ".rpak",
+		assetGuid,
 		hdrChunk.GetPointer(), hdrChunk.GetSize(),
 		PagePtr_t::NullPtr(), UINT64_MAX, UINT64_MAX, AssetType::SHDS);
 	asset.SetHeaderPointer(hdrChunk.Data());
@@ -221,9 +239,27 @@ void Assets::AddShaderSetAsset_v11(CPakFile* pak, const char* assetPath, rapidjs
 	if (hdr->numResources != 0)
 		Warning("Shader set '%s' has requested a non-zero number of shader resources. This feature is only intended for use on UI shaders, and may result in unexpected crashes or errors when used with incompatible shader code.\n", assetPath);
 
+	uint64_t assetGuid = 0;
+
+	if (JSON_IS_UINT64(mapEntry, "$guid"))
+	{
+		assetGuid = JSON_GET_UINT64(mapEntry, "guid", 0);
+	}
+	else if(JSON_IS_STR(mapEntry, "$guid"))
+	{
+		RTech::ParseGUIDFromString(JSON_GET_STR(mapEntry, "guid", ""), &assetGuid);
+	}
+	else
+	{
+		assetGuid = RTech::StringToGuid((assetPathWithoutExtension + ".rpak").c_str());
+	}
+
+	if (assetGuid == 0)
+		Error("Invalid GUID provided for asset '%s'.\n", assetPath);
+
 	PakAsset_t asset;
 	asset.InitAsset(
-		assetPathWithoutExtension + ".rpak",
+		assetGuid,
 		hdrChunk.GetPointer(), hdrChunk.GetSize(),
 		PagePtr_t::NullPtr(), UINT64_MAX, UINT64_MAX, AssetType::SHDS);
 	asset.SetHeaderPointer(hdrChunk.Data());

--- a/src/assets/shaderset.cpp
+++ b/src/assets/shaderset.cpp
@@ -38,10 +38,10 @@ void Assets::AddShaderSetAsset_v8(CPakFile* pak, const char* assetPath, rapidjso
 	const uint64_t pixelShaderGuid = RTech::GetAssetGUIDFromString(pixelShaderInput.c_str(), true);
 
 	if (vertexShaderGuid == 0)
-		Warning("No vertexShader field provided for shader set '%s'. Continuing without a vertex shader.\n", assetPathWithoutExtension.c_str());
+		Error("No vertexShader field provided for shader set '%s'.\n", assetPathWithoutExtension.c_str());
 
 	if (pixelShaderGuid == 0)
-		Warning("No pixelShader field provided for shader set '%s'. Continuing without a pixel shader.\n", assetPathWithoutExtension.c_str());
+		Error("No pixelShader field provided for shader set '%s'.\n", assetPathWithoutExtension.c_str());
 
 	hdr->vertexShader = vertexShaderGuid;
 	hdr->pixelShader = pixelShaderGuid;
@@ -153,10 +153,10 @@ void Assets::AddShaderSetAsset_v11(CPakFile* pak, const char* assetPath, rapidjs
 	const uint64_t pixelShaderGuid = RTech::GetAssetGUIDFromString(pixelShaderInput.c_str(), true);
 
 	if (vertexShaderGuid == 0)
-		Warning("No vertexShader field provided for shader set '%s'. Continuing without a vertex shader.\n", assetPathWithoutExtension.c_str());
+		Error("No vertexShader field provided for shader set '%s'.\n", assetPathWithoutExtension.c_str());
 
 	if (pixelShaderGuid == 0)
-		Warning("No pixelShader field provided for shader set '%s'. Continuing without a pixel shader.\n", assetPathWithoutExtension.c_str());
+		Error("No pixelShader field provided for shader set '%s'.\n", assetPathWithoutExtension.c_str());
 
 	hdr->vertexShader = vertexShaderGuid;
 	hdr->pixelShader = pixelShaderGuid;

--- a/src/assets/shaderset.cpp
+++ b/src/assets/shaderset.cpp
@@ -99,7 +99,7 @@ void Assets::AddShaderSetAsset_v8(CPakFile* pak, const char* assetPath, rapidjso
 	hdr->numResources = static_cast<uint8_t>(JSON_GET_UINT(mapEntry, "numResources", 0));
 
 	if (hdr->numResources != 0)
-		Warning("Shader set '%s' has requested a non-zero number of shader resources. This feature is only intended for use on UI shaders, and may result in unexpected crashes or errors when used with incompatible shader code.\n");
+		Warning("Shader set '%s' has requested a non-zero number of shader resources. This feature is only intended for use on UI shaders, and may result in unexpected crashes or errors when used with incompatible shader code.\n", assetPath);
 
 	PakAsset_t asset;
 	asset.InitAsset(
@@ -212,7 +212,7 @@ void Assets::AddShaderSetAsset_v11(CPakFile* pak, const char* assetPath, rapidjs
 	hdr->numResources = static_cast<uint8_t>(JSON_GET_UINT(mapEntry, "numResources", 0));
 
 	if (hdr->numResources != 0)
-		Warning("Shader set '%s' has requested a non-zero number of shader resources. This feature is only intended for use on UI shaders, and may result in unexpected crashes or errors when used with incompatible shader code.\n");
+		Warning("Shader set '%s' has requested a non-zero number of shader resources. This feature is only intended for use on UI shaders, and may result in unexpected crashes or errors when used with incompatible shader code.\n", assetPath);
 
 	PakAsset_t asset;
 	asset.InitAsset(

--- a/src/assets/shaderset.cpp
+++ b/src/assets/shaderset.cpp
@@ -38,19 +38,22 @@ void Assets::AddShaderSetAsset_v8(CPakFile* pak, const char* assetPath, rapidjso
 	const uint64_t pixelShaderGuid = RTech::GetAssetGUIDFromString(pixelShaderInput.c_str(), true);
 
 	if (vertexShaderGuid == 0)
-		Error("Invalid vertexShader field for shader set '%s'. Expected a string.\n", assetPathWithoutExtension.c_str());
+		Warning("No vertexShader field provided for shader set '%s'. Continuing without a vertex shader.\n", assetPathWithoutExtension.c_str());
 
 	if (pixelShaderGuid == 0)
-		Error("Invalid pixelShader field for shader set '%s'. Expected a string.\n", assetPathWithoutExtension.c_str());
+		Warning("No pixelShader field provided for shader set '%s'. Continuing without a pixel shader.\n", assetPathWithoutExtension.c_str());
 
 	hdr->vertexShader = vertexShaderGuid;
 	hdr->pixelShader = pixelShaderGuid;
 
-	pak->AddGuidDescriptor(&guids, hdrChunk.GetPointer(offsetof(ShaderSetAssetHeader_v8_t, vertexShader)));
-	pak->AddGuidDescriptor(&guids, hdrChunk.GetPointer(offsetof(ShaderSetAssetHeader_v8_t, pixelShader)));
+	if(hdr->vertexShader != 0)
+		pak->AddGuidDescriptor(&guids, hdrChunk.GetPointer(offsetof(ShaderSetAssetHeader_v8_t, vertexShader)));
 
-	PakAsset_t* const vertexShader = pak->GetAssetByGuid(vertexShaderGuid, nullptr, true);
-	PakAsset_t* const pixelShader = pak->GetAssetByGuid(pixelShaderGuid, nullptr, true);
+	if(hdr->pixelShader != 0)
+		pak->AddGuidDescriptor(&guids, hdrChunk.GetPointer(offsetof(ShaderSetAssetHeader_v8_t, pixelShader)));
+
+	PakAsset_t* const vertexShader = vertexShaderGuid != 0 ? pak->GetAssetByGuid(vertexShaderGuid, nullptr, true) : nullptr;
+	PakAsset_t* const pixelShader = pixelShaderGuid != 0 ? pak->GetAssetByGuid(pixelShaderGuid, nullptr, true) : nullptr;
 
 	if (vertexShader)
 	{
@@ -79,7 +82,7 @@ void Assets::AddShaderSetAsset_v8(CPakFile* pak, const char* assetPath, rapidjso
 		Debug("Overriding field \"numVertexShaderTextures\" for shader set '%s'.\n", assetPathWithoutExtension.c_str());
 		hdr->textureInputCounts[0] = static_cast<uint16_t>(JSON_GET_UINT(mapEntry, "numVertexShaderTextures", 0));
 	}
-	else if (!vertexShader)
+	else if (!vertexShader && hdr->vertexShader != 0) // warn if there is an asset guid, but it's not present in the current pak
 		Warning("Creating shader set '%s' without a local vertex shader asset and without a \'numVertexShaderTextures\' field. Shader set will assume 0 vertex shader textures.\n", assetPath);
 
 	if (JSON_IS_UINT(mapEntry, "numPixelShaderTextures"))
@@ -87,7 +90,7 @@ void Assets::AddShaderSetAsset_v8(CPakFile* pak, const char* assetPath, rapidjso
 		Debug("Overriding field \"numPixelShaderTextures\" for shader set '%s'.\n", assetPathWithoutExtension.c_str());
 		hdr->textureInputCounts[1] = static_cast<uint16_t>(JSON_GET_UINT(mapEntry, "numPixelShaderTextures", 0));
 	}
-	else if (!pixelShader)
+	else if (!pixelShader && hdr->pixelShader != 0) // warn if there is an asset guid, but it's not present in the current pak
 		Warning("Creating shader set '%s' without a local pixel shader asset and without a \'numPixelShaderTextures\' field. Shader set will assume 0 pixel shader textures.\n", assetPath);
 
 	hdr->numSamplers = static_cast<uint16_t>(JSON_GET_UINT(mapEntry, "numSamplers", 0));
@@ -148,20 +151,22 @@ void Assets::AddShaderSetAsset_v11(CPakFile* pak, const char* assetPath, rapidjs
 	const uint64_t pixelShaderGuid = RTech::GetAssetGUIDFromString(pixelShaderInput.c_str(), true);
 
 	if (vertexShaderGuid == 0)
-		Error("Invalid vertexShader field for shader set '%s'. Expected a string.\n", assetPathWithoutExtension.c_str());
+		Warning("No vertexShader field provided for shader set '%s'. Continuing without a vertex shader.\n", assetPathWithoutExtension.c_str());
 
 	if (pixelShaderGuid == 0)
-		Error("Invalid pixelShader field for shader set '%s'. Expected a string.\n", assetPathWithoutExtension.c_str());
+		Warning("No pixelShader field provided for shader set '%s'. Continuing without a pixel shader.\n", assetPathWithoutExtension.c_str());
 
 	hdr->vertexShader = vertexShaderGuid;
 	hdr->pixelShader = pixelShaderGuid;
 
-	pak->AddGuidDescriptor(&guids, hdrChunk.GetPointer(offsetof(ShaderSetAssetHeader_v11_t, vertexShader)));
-	pak->AddGuidDescriptor(&guids, hdrChunk.GetPointer(offsetof(ShaderSetAssetHeader_v11_t, pixelShader)));
+	if (hdr->vertexShader != 0)
+		pak->AddGuidDescriptor(&guids, hdrChunk.GetPointer(offsetof(ShaderSetAssetHeader_v11_t, vertexShader)));
 
+	if (hdr->pixelShader != 0)
+		pak->AddGuidDescriptor(&guids, hdrChunk.GetPointer(offsetof(ShaderSetAssetHeader_v11_t, pixelShader)));
 
-	PakAsset_t* const vertexShader = pak->GetAssetByGuid(vertexShaderGuid, nullptr, true);
-	PakAsset_t* const pixelShader = pak->GetAssetByGuid(pixelShaderGuid, nullptr, true);
+	PakAsset_t* const vertexShader = vertexShaderGuid != 0 ? pak->GetAssetByGuid(vertexShaderGuid, nullptr, true) : nullptr;
+	PakAsset_t* const pixelShader = pixelShaderGuid != 0 ? pak->GetAssetByGuid(pixelShaderGuid, nullptr, true) : nullptr;
 
 	if (pixelShader)
 	{
@@ -192,7 +197,7 @@ void Assets::AddShaderSetAsset_v11(CPakFile* pak, const char* assetPath, rapidjs
 		Warning("Overriding field \"numVertexShaderTextures\" for shader set '%s'.\n", assetPathWithoutExtension.c_str());
 		hdr->textureInputCounts[0] = static_cast<uint16_t>(JSON_GET_UINT(mapEntry, "numVertexShaderTextures", 0));
 	}
-	else if (!vertexShader)
+	else if (!vertexShader && hdr->vertexShader != 0) // warn if there is an asset guid, but it's not present in the current pak
 		Warning("Creating shader set '%s' without a local vertex shader asset and without a \'numVertexShaderTextures\' field. Shader set will assume 0 vertex shader textures.\n", assetPath);
 
 	if (JSON_IS_UINT(mapEntry, "numPixelShaderTextures"))
@@ -200,7 +205,7 @@ void Assets::AddShaderSetAsset_v11(CPakFile* pak, const char* assetPath, rapidjs
 		Warning("Overriding field \"numPixelShaderTextures\" for shader set '%s'.\n", assetPathWithoutExtension.c_str());
 		hdr->textureInputCounts[1] = static_cast<uint16_t>(JSON_GET_UINT(mapEntry, "numPixelShaderTextures", 0));
 	}
-	else if (!pixelShader)
+	else if (!pixelShader && hdr->pixelShader != 0) // warn if there is an asset guid, but it's not present in the current pak
 		Warning("Creating shader set '%s' without a local pixel shader asset and without a \'numPixelShaderTextures\' field. Shader set will assume 0 pixel shader textures.\n", assetPath);
 
 	hdr->numSamplers = static_cast<uint16_t>(JSON_GET_UINT(mapEntry, "numSamplers", 0));

--- a/src/assets/texture.cpp
+++ b/src/assets/texture.cpp
@@ -4,7 +4,7 @@
 #include "public/texture.h"
 
 // materialGeneratedTexture - whether this texture's creation was invoked by material automatic texture generation
-void Assets::AddTextureAsset(CPakFile* pak, const uint64_t guid, const char* assetPath, bool forceDisableStreaming, bool materialGeneratedTexture)
+void Assets::AddTextureAsset(CPakFile* pak, uint64_t guid, const char* assetPath, bool forceDisableStreaming, bool materialGeneratedTexture)
 {
     Log("Adding txtr asset '%s'\n", assetPath);
 
@@ -236,6 +236,8 @@ void Assets::AddTextureAsset(CPakFile* pak, const uint64_t guid, const char* ass
         // do stuff
     }
 
+    if (guid == 0)
+        guid = RTech::StringToGuid((sAssetName + ".rpak").c_str());
 
     asset.InitAsset(guid, hdrChunk.GetPointer(), hdrChunk.GetSize(), dataChunk.GetPointer(), starpakOffset, UINT64_MAX, AssetType::TXTR);
     asset.SetHeaderPointer(hdrChunk.Data());

--- a/src/assets/uiatlas.cpp
+++ b/src/assets/uiatlas.cpp
@@ -58,7 +58,7 @@ void Assets::AddUIImageAsset_v10(CPakFile* pak, const char* assetPath, rapidjson
     std::string sAtlasFilePath = pak->GetAssetPath() + mapEntry["atlas"].GetStdString() + ".dds";
     std::string sAtlasAssetName = mapEntry["atlas"].GetStdString() + ".rpak";
 
-    AddTextureAsset(pak, mapEntry["atlas"].GetString(), mapEntry.HasMember("disableStreaming") && mapEntry["disableStreaming"].GetBool(), true);
+    AddTextureAsset(pak, 0, mapEntry["atlas"].GetString(), mapEntry.HasMember("disableStreaming") && mapEntry["disableStreaming"].GetBool(), true);
 
     uint64_t atlasGuid = RTech::StringToGuid(sAtlasAssetName.c_str());
 

--- a/src/logic/pakfile.cpp
+++ b/src/logic/pakfile.cpp
@@ -51,7 +51,7 @@ void CPakFile::AddAsset(rapidjson::Value& file)
 	AddJSONAsset("arig", file, nullptr, Assets::AddAnimRigAsset_v4);
 
 	AddJSONAsset("shds", file, Assets::AddShaderSetAsset_v8, nullptr);
-	AddJSONAsset("shdr", file, Assets::AddShaderAsset_v8, nullptr);
+	AddJSONAsset("shdr", file, Assets::AddShaderAsset_v8, Assets::AddShaderAsset_v12);
 
 }
 

--- a/src/logic/pakfile.cpp
+++ b/src/logic/pakfile.cpp
@@ -282,10 +282,7 @@ void CPakFile::WritePageData(BinaryIO& out)
 //-----------------------------------------------------------------------------
 size_t CPakFile::WriteStarpakPaths(BinaryIO& out, bool optional)
 {
-	if (optional)
-		return Utils::WriteStringVector(out, m_vOptStarpakPaths);
-	else
-		return Utils::WriteStringVector(out, m_vStarpakPaths);
+	return Utils::WriteStringVector(out, optional ? m_vOptStarpakPaths : m_vStarpakPaths);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/logic/pakfile.cpp
+++ b/src/logic/pakfile.cpp
@@ -8,7 +8,7 @@
 #include "pakfile.h"
 #include "assets/assets.h"
 
-void CPakFile::AddJSONAsset(const char* type, rapidjson::Value& file, AssetTypeFunc_t func_r2, AssetTypeFunc_t func_r5)
+bool CPakFile::AddJSONAsset(const char* type, rapidjson::Value& file, AssetTypeFunc_t func_r2, AssetTypeFunc_t func_r5)
 {
 	if (file["$type"].GetStdString() == type)
 	{
@@ -33,26 +33,34 @@ void CPakFile::AddJSONAsset(const char* type, rapidjson::Value& file, AssetTypeF
 			targetFunc(this, file["path"].GetString(), file);
 		else
 			Warning("Asset type '%s' is not supported on RPak version %i\n", type, fileVersion);
+
+		// Asset type has been handled.
+		return true;
 	}
+	else return false;
 }
+
+#define HANDLE_ASSET_TYPE(type, asset, func_r2, func_r5) if (AddJSONAsset(type, asset, func_r2, func_r5)) return;
 
 //-----------------------------------------------------------------------------
 // purpose: installs asset types and their callbacks
 //-----------------------------------------------------------------------------
 void CPakFile::AddAsset(rapidjson::Value& file)
 {
-	AddJSONAsset("txtr", file, Assets::AddTextureAsset_v8, Assets::AddTextureAsset_v8);
-	AddJSONAsset("uimg", file, Assets::AddUIImageAsset_v10, Assets::AddUIImageAsset_v10);
-	AddJSONAsset("Ptch", file, Assets::AddPatchAsset, Assets::AddPatchAsset);
-	AddJSONAsset("dtbl", file, Assets::AddDataTableAsset, Assets::AddDataTableAsset);
-	AddJSONAsset("matl", file, Assets::AddMaterialAsset_v12, Assets::AddMaterialAsset_v15);
-	AddJSONAsset("rmdl", file, nullptr, Assets::AddModelAsset_v9);
-	AddJSONAsset("aseq", file, nullptr, Assets::AddAnimSeqAsset_v7);
-	AddJSONAsset("arig", file, nullptr, Assets::AddAnimRigAsset_v4);
+	HANDLE_ASSET_TYPE("txtr", file, Assets::AddTextureAsset_v8, Assets::AddTextureAsset_v8);
+	HANDLE_ASSET_TYPE("uimg", file, Assets::AddUIImageAsset_v10, Assets::AddUIImageAsset_v10);
+	HANDLE_ASSET_TYPE("Ptch", file, Assets::AddPatchAsset, Assets::AddPatchAsset);
+	HANDLE_ASSET_TYPE("dtbl", file, Assets::AddDataTableAsset, Assets::AddDataTableAsset);
+	HANDLE_ASSET_TYPE("matl", file, Assets::AddMaterialAsset_v12, Assets::AddMaterialAsset_v15);
+	HANDLE_ASSET_TYPE("rmdl", file, nullptr, Assets::AddModelAsset_v9);
+	HANDLE_ASSET_TYPE("aseq", file, nullptr, Assets::AddAnimSeqAsset_v7);
+	HANDLE_ASSET_TYPE("arig", file, nullptr, Assets::AddAnimRigAsset_v4);
 
-	AddJSONAsset("shds", file, Assets::AddShaderSetAsset_v8, Assets::AddShaderSetAsset_v11);
-	AddJSONAsset("shdr", file, Assets::AddShaderAsset_v8, Assets::AddShaderAsset_v12);
+	HANDLE_ASSET_TYPE("shds", file, Assets::AddShaderSetAsset_v8, Assets::AddShaderSetAsset_v11);
+	HANDLE_ASSET_TYPE("shdr", file, Assets::AddShaderAsset_v8, Assets::AddShaderAsset_v12);
 
+	// If the function has not returned by this point, we have an invalid asset type name.
+	Error("Invalid asset type '%s' provided for asset '%s'.\n", JSON_GET_STR(file, "$type", "(invalid)"), JSON_GET_STR(file, "path", "(unknown)"));
 }
 
 //-----------------------------------------------------------------------------

--- a/src/logic/pakfile.h
+++ b/src/logic/pakfile.h
@@ -122,7 +122,7 @@ public:
 
 	typedef void(*AssetTypeFunc_t)(CPakFile*, const char*, rapidjson::Value&);
 
-	void AddJSONAsset(const char* type, rapidjson::Value& file, AssetTypeFunc_t func_r2 = nullptr, AssetTypeFunc_t func_r5 = nullptr);
+	bool AddJSONAsset(const char* type, rapidjson::Value& file, AssetTypeFunc_t func_r2 = nullptr, AssetTypeFunc_t func_r5 = nullptr);
 	void AddAsset(rapidjson::Value& file);
 	void AddPointer(PagePtr_t ptr);
 	void AddPointer(int pageIdx, int pageOffset);

--- a/src/logic/pakfile.h
+++ b/src/logic/pakfile.h
@@ -79,24 +79,33 @@ class CPakDataChunk
 public:
 	CPakDataChunk() = default;
 
-	CPakDataChunk(size_t size, uint8_t alignment, char* data) : size((int)size), alignment(alignment), pData(data) {};
-	CPakDataChunk(int pageIndex, int pageOffset, size_t size, uint8_t alignment, char* data) : pageIndex(pageIndex), pageOffset(pageOffset), size((int)size), alignment(alignment), pData(data) {};
+	CPakDataChunk(size_t size, uint8_t alignment, char* data) : size((int)size), alignment(alignment), pData(data), released(false) {};
+	CPakDataChunk(int pageIndex, int pageOffset, size_t size, uint8_t alignment, char* data) : pageIndex(pageIndex), pageOffset(pageOffset), size((int)size), alignment(alignment), pData(data), released(false) {};
 
 private:
 	int pageIndex;
 	int pageOffset;
 	int size;
-	uint8_t alignment;
 
 	char* pData;
-
+	uint8_t alignment;
+	bool released;
 public:
 
 	inline PagePtr_t GetPointer(size_t offset=0) { return { pageIndex, static_cast<int>(pageOffset + offset) }; };
 
-	int GetIndex() { return pageIndex; };
-	char* Data() { return pData; };
-	int GetSize() { return size; };
+	inline int GetIndex() const { return pageIndex; };
+	inline char* Data() { return pData; };
+	inline int GetSize() const { return size; };
+	inline bool IsReleased() const { return released; };
+
+	inline void Release()
+	{
+		delete[] pData;
+		
+		this->pData = nullptr;
+		this->released = true;
+	}
 };
 
 class CPakFile

--- a/src/logic/rtech.cpp
+++ b/src/logic/rtech.cpp
@@ -1,62 +1,150 @@
 #include "pch.h"
 #include "rtech.h"
 
-std::uint64_t __fastcall RTech::StringToGuid(const char* pData)
+// compute a guid from input string data that resides in a memory address that
+// is aligned to a 4 byte boundary
+static PakGuid_t StringToGuidAligned(const char* string)
 {
-	std::uint32_t* v1; // r8
-	std::uint64_t         v2; // r10
-	int                   v3; // er11
-	std::uint32_t         v4; // er9
-	std::uint32_t          i; // edx
-	std::uint64_t         v6; // rcx
-	int                   v7; // er9
-	int                   v8; // edx
-	int                   v9; // eax
-	std::uint32_t        v10; // er8
-	int                  v12; // ecx
-	std::uint32_t* a1 = (std::uint32_t*)pData;
+	uint64_t         v1; // r9
+	int               i; // r11d
+	uint32_t         v4; // edi
+	int              v5; // ebp
+	int              v6; // r10d
+	uint32_t         v7; // ecx
+	uint32_t         v8; // edx
+	uint32_t         v9; // eax
+	uint32_t        v10; // r8d
+	int64_t         v11; // r10
+	uint64_t        v12; // r8
+	int             v13; // eax
+	int             v15; // ecx
 
-	v1 = a1;
-	v2 = 0i64;
-	v3 = 0;
-	v4 = (*a1 - 45 * ((~(*a1 ^ 0x5C5C5C5Cu) >> 7) & (((*a1 ^ 0x5C5C5C5Cu) - 0x1010101) >> 7) & 0x1010101)) & 0xDFDFDFDF;
-	for (i = ~*a1 & (*a1 - 0x1010101) & 0x80808080; !i; i = v8 & 0x80808080)
+	v1 = 0ull;
+	for (i = 0; ; i += 4)
 	{
-		v6 = v4;
-		v7 = v1[1];
-		++v1;
-		v3 += 4;
-		v2 = ((((std::uint64_t)(0xFB8C4D96501i64 * v6) >> 24) + 0x633D5F1 * v2) >> 61) ^ (((std::uint64_t)(0xFB8C4D96501i64 * v6) >> 24)
-			+ 0x633D5F1 * v2);
-		v8 = ~v7 & (v7 - 0x1010101);
-		v4 = (v7 - 45 * ((~(v7 ^ 0x5C5C5C5Cu) >> 7) & (((v7 ^ 0x5C5C5C5Cu) - 0x1010101) >> 7) & 0x1010101)) & 0xDFDFDFDF;
+		v4 = ~*(uint32_t*)string & (*(uint32_t*)string - 0x1010101) & 0x80808080;
+		v5 = v4 ^ (v4 - 1);
+		v6 = v5 & *(uint32_t*)string ^ 0x5C5C5C5C;
+		v7 = ~v6 & (v6 - 0x1010101) & 0x80808080;
+		v8 = v7 & -(int32_t)v7;
+		if (v7 != v8)
+		{
+			v9 = 0xFF000000;
+			do
+			{
+				v10 = v9;
+				if ((v9 & v6) == 0)
+					v8 |= v9 & 0x80808080;
+				v9 >>= 8;
+			} while (v10 >= 0x100);
+		}
+		v11 = 0x633D5F1 * v1;
+		v12 = (0xFB8C4D96501i64 * (uint64_t)(((v5 & *(uint32_t*)string) - 45 * (v8 >> 7)) & 0xDFDFDFDF)) >> 24;
+		if (v4)
+			break;
+		string += 4;
+		v1 = ((v11 + v12) >> 61) ^ (v11 + v12);
 	}
-	v9 = -1;
-	v10 = (i & -(signed)i) - 1;
-	if (_BitScanReverse((unsigned long*)&v12, v10))
-	{
-		v9 = v12;
-	}
-	return 0x633D5F1 * v2 + ((0xFB8C4D96501i64 * (std::uint64_t)(v4 & v10)) >> 24) - 0xAE502812AA7333i64 * (std::uint32_t)(v3 + v9 / 8);
+	v13 = -1;
+	if (_BitScanReverse((unsigned long*)&v15, v5))
+		v13 = v15;
+	return v12 + v11 - 0xAE502812AA7333i64 * (uint32_t)(i + v13 / 8);
 }
 
-std::uint32_t __fastcall RTech::StringToUIMGHash(const char* str)
+// compute a guid from input string data that resides in a memory address that
+// isn't aligned to a 4 byte boundary
+static PakGuid_t StringToGuidUnaligned(const char* string)
 {
-	std::uint64_t r = StringToGuid(str);
-	unsigned int l = (r & 0xFFFFFFFF);
-	unsigned int h = (r >> 32);
+	uint64_t        v1; // rbx
+	uint64_t        v2; // r10
+	int              i; // esi
+	int             v4; // edx
+	uint32_t        v5; // edi
+	int             v6; // ebp
+	int             v7; // edx
+	uint32_t        v8; // ecx
+	uint32_t        v9; // r8d
+	uint32_t       v10; // eax
+	uint32_t       v11; // r9d
+	int64_t        v12; // r9
+	uint64_t       v13; // r8
+	int            v14; // eax
+	int            v16; // ecx
 
-	unsigned int x = l ^ h;
-
-	return x;
+	v1 = 0ull;
+	v2 = (uint64_t)(string + 3);
+	for (i = 0; ; i += 4)
+	{
+		if ((v2 ^ (v2 - 3)) >= 0x1000)
+		{
+			v4 = *(uint8_t*)(v2 - 3);
+			if ((uint8_t)v4)
+			{
+				v4 = *(uint16_t*)(v2 - 3);
+				if (*(uint8_t*)(v2 - 2))
+				{
+					v4 |= *(uint8_t*)(v2 - 1) << 16;
+					if (*(uint8_t*)(v2 - 1))
+						v4 |= *(uint8_t*)v2 << 24;
+				}
+			}
+		}
+		else
+		{
+			v4 = *(uint32_t*)(v2 - 3);
+		}
+		v5 = ~v4 & (v4 - 0x1010101) & 0x80808080;
+		v6 = v5 ^ (v5 - 1);
+		v7 = v6 & v4;
+		v8 = ~(v7 ^ 0x5C5C5C5C) & ((v7 ^ 0x5C5C5C5C) - 0x1010101) & 0x80808080;
+		v9 = v8 & -(int32_t)v8;
+		if (v8 != v9)
+		{
+			v10 = 0xFF000000;
+			do
+			{
+				v11 = v10;
+				if ((v10 & (v7 ^ 0x5C5C5C5C)) == 0)
+					v9 |= v10 & 0x80808080;
+				v10 >>= 8;
+			} while (v11 >= 0x100);
+		}
+		v12 = 0x633D5F1 * v1;
+		v13 = (0xFB8C4D96501i64 * (uint64_t)((v7 - 45 * (v9 >> 7)) & 0xDFDFDFDF)) >> 24;
+		if (v5)
+			break;
+		v2 += 4i64;
+		v1 = ((v12 + v13) >> 61) ^ (v12 + v13);
+	}
+	v14 = -1;
+	if (_BitScanReverse((unsigned long*)&v16, v6))
+		v14 = v16;
+	return v13 + v12 - 0xAE502812AA7333i64 * (uint32_t)(i + v14 / 8);
 }
 
-std::uint64_t RTech::GetAssetGUIDFromString(const char* str, bool forceRpakExtension)
+PakGuid_t RTech::StringToGuid(const char* const string)
+{
+	return ((uintptr_t)string & 3)
+		? StringToGuidUnaligned(string)
+		: StringToGuidAligned(string);
+}
+
+std::uint32_t RTech::StringToUIMGHash(const char* const str)
+{
+	const PakGuid_t guid = RTech::StringToGuid(str);
+
+	const unsigned int l = (guid & 0xFFFFFFFF);
+	const unsigned int h = (guid >> 32);
+
+	return l ^ h;
+}
+
+PakGuid_t RTech::GetAssetGUIDFromString(const char* const str, const bool forceRpakExtension)
 {
 	if (strlen(str) == 0)
 		return 0;
 
-	uint64_t guid = 0;
+	PakGuid_t guid = 0;
 
 	// check for upper and lower case hex guids (e.g. 0x5DCAT, 0x5dcat)
 	if (!sscanf_s(str, "0x%llX", &guid) && !sscanf_s(str, "0x%llx", &guid))
@@ -70,11 +158,11 @@ std::uint64_t RTech::GetAssetGUIDFromString(const char* str, bool forceRpakExten
 	return guid;
 }
 
-bool RTech::ParseGUIDFromString(const char* str, uint64_t* pGuid)
+bool RTech::ParseGUIDFromString(const char* const str, PakGuid_t* const pGuid)
 {
-	uint64_t guid = 0;
+	PakGuid_t guid = 0;
 
-	bool found = sscanf_s(str, "0x%llX", &guid) || sscanf_s(str, "0x%llx", &guid);
+	const bool found = sscanf_s(str, "0x%llX", &guid) || sscanf_s(str, "0x%llx", &guid);
 
 	if (found && pGuid != nullptr)
 		*pGuid = guid;

--- a/src/logic/rtech.h
+++ b/src/logic/rtech.h
@@ -1,5 +1,8 @@
 #pragma once
 
+// todo(amos): reorder headers so this can be moved into public.
+typedef uint64_t PakGuid_t;
+
 // contains the offset and size of a data entry within the starpak
 // offset must be larger than 0x1000 (4096), as the beginning of 
 // the file is filled with 0xCB until that point
@@ -14,9 +17,9 @@ struct SRPkFileEntry
 
 namespace RTech
 {
-	std::uint64_t __fastcall StringToGuid(const char* pData);
-	std::uint32_t __fastcall StringToUIMGHash(const char* str);
+	PakGuid_t StringToGuid(const char* const string);
+	std::uint32_t StringToUIMGHash(const char* const str);
 
-	bool ParseGUIDFromString(const char* str, uint64_t* pGuid = nullptr);
-	std::uint64_t GetAssetGUIDFromString(const char* str, bool forceRpakExtension = false);
+	bool ParseGUIDFromString(const char* const str, PakGuid_t* const pGuid = nullptr);
+	PakGuid_t GetAssetGUIDFromString(const char* const str, const bool forceRpakExtension = false);
 }

--- a/src/pch.h
+++ b/src/pch.h
@@ -12,9 +12,12 @@
 #include <string>
 #include <fstream>
 #include <regex>
+
 #include <rapidcsv/rapidcsv.h>
+
 #include <rapidjson/document.h>
 #include <rapidjson/istreamwrapper.h>
+#include "rapidjson/prettywriter.h"
 
 #include "common/decls.h"
 #include "common/const.h"

--- a/src/pch.h
+++ b/src/pch.h
@@ -24,6 +24,7 @@
 
 #include "utils/binaryio.h"
 #include "utils/utils.h"
+#include "utils/strutils.h"
 #include "utils/logger.h"
 
 #define UNUSED(x)	(void)(x)

--- a/src/pch.h
+++ b/src/pch.h
@@ -25,6 +25,7 @@
 #include "utils/binaryio.h"
 #include "utils/utils.h"
 #include "utils/strutils.h"
+#include "utils/jsonutils.h"
 #include "utils/logger.h"
 
 #define UNUSED(x)	(void)(x)

--- a/src/public/multishader.h
+++ b/src/public/multishader.h
@@ -1,0 +1,386 @@
+#pragma once
+#include <stdlib.h>
+
+#undef DOMAIN // go away
+
+// Definitions for the custom MultiShaderWrapper format
+// This file is used for exporting and storing all information relating to both Shader and ShaderSet assets
+//
+// Types of file:
+// - Shader
+//   - Stores all compiled shader buffers as exported from the game asset CPU data
+//   - This uses multiple buffers because shader assets can have different versions of the same shader to support different features 
+//     (such as dither fading, instancing, or a combination of them (and maybe others, but this is all i have seen actually being used))
+// - ShaderSet
+//   - Stores information for both of the shaders referenced by the game asset.
+//   - Ultimately points to two Shader data headers, as if the file contained two separate "Shader" MSW files.
+
+
+// Shader files:
+//
+// File Header        - MultiShaderWrapper_Header_t       - Defines file-wide information.
+// Shader Header      - MultiShaderWrapper_Shader_t       - Defines shader-specific information.
+// Shader Descriptors - MultiShaderWrapper_ShaderDesc_t[] - Describes location of individual shader files within the wrapper.
+//                                                        - Array size depends on Shader Header variable.
+
+#ifndef MSW_FOURCC
+#define MSW_FOURCC(a, b, c, d) (a | (b << 8) | (c << 16) | (d << 24))
+#endif
+
+#define MSW_FILE_MAGIC ('M' | ('S' << 8) | ('W' << 16))
+
+// Only updated for breaking changes.
+#define MSW_FILE_VER 1
+
+enum class MultiShaderWrapperFileType_e : unsigned char
+{
+	SHADER = 0,
+	SHADERSET = 1,
+};
+
+enum class MultiShaderWrapperShaderType_e : unsigned char
+{
+	PIXEL = 0,
+	VERTEX = 1,
+	GEOMETRY = 2,
+	HULL = 3,
+	DOMAIN = 4,
+	COMPUTE = 5,
+	INVALID = 0xFF
+};
+
+#pragma pack(push, 1)
+struct MultiShaderWrapper_Header_t
+{
+	unsigned int magic : 24;    // Identifies this file as being a MSW file.
+	unsigned int version : 8; // Used to return early when loading an older (incompatible) version of the file format.
+	MultiShaderWrapperFileType_e fileType; // What type of wrapper is this?
+};
+static_assert(sizeof(MultiShaderWrapper_Header_t) == 5);
+
+struct MultiShaderWrapper_ShaderSet_t
+{
+	// For R5-exported assets, these should both always be set, but in the event that a shaderset doesn't have one of the shader types,
+	// we need to make sure that the parser only tries to read valid data.
+	bool hasPixelShader : 1;
+	bool hasVertexShader : 1;
+};
+static_assert(sizeof(MultiShaderWrapper_ShaderSet_t) == 1);
+
+struct MultiShaderWrapper_Shader_t
+{
+	// shaderFeatures MUST be the first member of this struct! see WriteShader.
+	unsigned __int64 shaderFeatures : 56; // Defines some shader counts.
+	unsigned __int64 numShaderDescriptors : 8;  // Number of MultiShaderWrapper_ShaderDesc_t struct instances before file data.
+};
+static_assert(sizeof(MultiShaderWrapper_Shader_t) == 8);
+
+struct MultiShaderWrapper_ShaderDesc_t
+{
+	// Represents a regular shader entry. These shaders have their own file data, pointed to by the "bufferOffset" member.
+	// This offset is relative to the start of the MSW_ShaderDesc_t struct instance in the file.
+	struct _StandardShader
+	{
+		unsigned int bufferLength;
+		unsigned int bufferOffset;
+	};
+
+	// Represents a reference shader entry. These shaders do not have their own file data, and point to a lower index of standard shader
+	// to re-use their shader buffer.
+	struct _ReferenceShader
+	{
+		unsigned int bufferIndex;
+
+		// This upper DWORD must be 0 on reference shaders so that they can be identified as references.
+		// As the buffer offset of standard shaders are relative to the start of the MSW_ShaderDesc_t struct, the value will never be 0.
+		// Therefore, if the value is 0, the shader is a reference to another shader's data.
+		unsigned int _reserved;
+	};
+
+	union
+	{
+		_StandardShader u_standard;
+		_ReferenceShader u_ref;
+	};
+};
+#pragma pack(pop)
+
+#include <vector> // this will be removed eventuallytm
+
+// class for handling reading/writing of MSW files from memory structures
+class CMultiShaderWrapperIO
+{
+public:
+	struct ShaderEntry_t
+	{
+		const char* buffer;
+		unsigned int size;
+
+		unsigned short refIndex; // if this shader entry is a reference. do not set "buffer" if this is used
+	};
+
+	struct Shader_t
+	{
+		Shader_t() : shaderType(MultiShaderWrapperShaderType_e::INVALID), features{} {};
+		Shader_t(MultiShaderWrapperShaderType_e type) : shaderType(type), features{} {};
+
+		std::vector<ShaderEntry_t> entries;
+		MultiShaderWrapperShaderType_e shaderType;
+		unsigned char features[7];
+	};
+
+	struct ShaderFile_t
+	{
+		MultiShaderWrapperFileType_e type;
+
+		union
+		{
+			Shader_t* shader; // Used if type == SHADER
+
+			struct {
+				Shader_t* pixelShader;
+				Shader_t* vertexShader;
+			} shaderSet; // Used if type == SHADERSET
+		};
+	};
+public:
+	CMultiShaderWrapperIO() = default;
+
+	inline void SetFileType(MultiShaderWrapperFileType_e type) { _fileType = type; };
+
+	inline void SetShader(Shader_t* shader)
+	{
+		if (!shader)
+			return;
+
+		if (_fileType == MultiShaderWrapperFileType_e::SHADER)
+			this->_storedShaders.shader = shader;
+		else if (_fileType == MultiShaderWrapperFileType_e::SHADERSET)
+		{
+			switch (shader->shaderType)
+			{
+			case MultiShaderWrapperShaderType_e::PIXEL:
+			{
+				this->_storedShaders.shaderSet.pixelShader = shader;
+				break;
+			}
+			case MultiShaderWrapperShaderType_e::VERTEX:
+			{
+				this->_storedShaders.shaderSet.vertexShader = shader;
+				break;
+			}
+			default:
+				return;
+			}
+		}
+
+		writtenAnything = true;
+	}
+
+	bool ReadFile(const char* filePath, ShaderFile_t* outFile)
+	{
+		if (!outFile)
+			return false;
+
+		FILE* f = NULL;
+
+		if (fopen_s(&f, filePath, "rb") == 0)
+		{
+			MultiShaderWrapper_Header_t fileHeader = {};
+
+			fread(&fileHeader, sizeof(fileHeader), 1, f);
+			outFile->type = fileHeader.fileType;
+
+			if (fileHeader.fileType == MultiShaderWrapperFileType_e::SHADERSET)
+			{
+				// will be supported eventuallytm
+				return false;
+			}
+			else if (fileHeader.fileType == MultiShaderWrapperFileType_e::SHADER)
+			{
+				Shader_t* shader = new Shader_t;
+
+				ReadShader(f, shader);
+
+				outFile->shader = shader;
+			}
+
+			return true;
+		}
+		else
+			return false;
+	}
+
+	void ReadShaderSet() {};
+
+	// Allocate a shader before calling this
+	void ReadShader(FILE* f, Shader_t* outShader)
+	{
+		MultiShaderWrapper_Shader_t shdr = {};
+
+		fread(&shdr, sizeof(shdr), 1, f);
+
+		const size_t descStartOffset = ftell(f);
+
+		MultiShaderWrapper_ShaderDesc_t* descriptors = new MultiShaderWrapper_ShaderDesc_t[shdr.numShaderDescriptors];
+		for (int i = 0; i < shdr.numShaderDescriptors; ++i)
+		{
+			const size_t thisDescOffset = descStartOffset + (i * sizeof(MultiShaderWrapper_ShaderDesc_t));
+
+			fseek(f, static_cast<long>(thisDescOffset), SEEK_SET);
+
+			MultiShaderWrapper_ShaderDesc_t* desc = &descriptors[i];
+			fread(desc, sizeof(MultiShaderWrapper_ShaderDesc_t), 1, f);
+
+			ShaderEntry_t entry = {};
+
+			if (desc->u_ref.bufferIndex == UINT32_MAX && desc->u_ref._reserved == UINT32_MAX)
+			{
+				// null shader entry
+				entry.refIndex = UINT16_MAX;
+			}
+			else if (desc->u_ref._reserved == 0 && desc->u_ref.bufferIndex != UINT32_MAX)
+			{
+				entry.refIndex = static_cast<unsigned short>(desc->u_ref.bufferIndex);
+			}
+			else
+			{
+				// regular shader - get buffer and allocate it some new space to go into the shader entry vector
+				fseek(f, static_cast<long>(thisDescOffset + desc->u_standard.bufferOffset), SEEK_SET);
+
+				char* buffer = new char[desc->u_standard.bufferLength];
+
+				fread(buffer, sizeof(char), desc->u_standard.bufferLength, f);
+
+				entry.buffer = buffer;
+				entry.size = desc->u_standard.bufferLength;
+				entry.refIndex = UINT16_MAX;
+			}
+
+			outShader->entries.push_back(entry);
+
+			// shader type isn't saved, so it has to be found from the shader bytecode separately
+			outShader->shaderType = MultiShaderWrapperShaderType_e::INVALID;
+
+			memcpy(outShader->features, &shdr, sizeof(outShader->features));
+		}
+	}
+
+	__forceinline bool WriteFile(const char* filePath)
+	{
+		if (!writtenAnything)
+			return false;
+
+		FILE* f = NULL;
+
+		if (fopen_s(&f, filePath, "wb") == 0)
+		{
+			MultiShaderWrapper_Header_t fileHeader =
+			{
+				.magic = MSW_FILE_MAGIC,
+				.version = MSW_FILE_VER,
+				.fileType = this->_fileType
+			};
+
+			fwrite(&fileHeader, sizeof(MultiShaderWrapper_Header_t), 1, f);
+
+			if (_fileType == MultiShaderWrapperFileType_e::SHADERSET)
+				WriteShaderSet(f);
+			else if (_fileType == MultiShaderWrapperFileType_e::SHADER)
+				WriteShader(f, _storedShaders.shader);
+
+
+			fclose(f);
+			return true;
+		}
+		return false;
+	}
+
+private:
+	inline void WriteShaderSet(FILE* f)
+	{
+		MultiShaderWrapper_ShaderSet_t shaderSet =
+		{
+			.hasPixelShader = _storedShaders.shaderSet.pixelShader != nullptr,
+			.hasVertexShader = _storedShaders.shaderSet.vertexShader != nullptr
+		};
+
+		fwrite(&shaderSet, sizeof(shaderSet), 1, f);
+
+		if (shaderSet.hasPixelShader)
+			this->WriteShader(f, _storedShaders.shaderSet.pixelShader);
+		if (shaderSet.hasVertexShader)
+			this->WriteShader(f, _storedShaders.shaderSet.vertexShader);
+	}
+
+	inline void WriteShader(FILE* f, const Shader_t* shader)
+	{
+		MultiShaderWrapper_Shader_t shdr =
+		{
+			.numShaderDescriptors = shader->entries.size()
+		};
+
+		// Copy to the start of the struct, since we can't copy directly to a bitfield
+		memcpy_s(&shdr, sizeof(shader->features), shader->features, sizeof(shader->features));
+
+		fwrite(&shdr, sizeof(shdr), 1, f);
+
+		const size_t descStartOffset = ftell(f);
+		size_t bufferWriteOffset = descStartOffset + (shader->entries.size() * sizeof(MultiShaderWrapper_ShaderDesc_t));
+
+		// Skip the description structs for now, since we can write those at the same time as the buffers.
+		// Buffer writing has to come back here to set the offset, so we might as well do it all in one go!
+		fseek(f, static_cast<long>(bufferWriteOffset), SEEK_SET);
+
+		size_t entryIndex = 0;
+		for (auto& entry : shader->entries)
+		{
+			const size_t thisDescOffset = descStartOffset + (entryIndex * sizeof(MultiShaderWrapper_ShaderDesc_t));
+
+			MultiShaderWrapper_ShaderDesc_t desc = {};
+
+			// If there is a valid buffer pointer, this entry is standard.
+			if (entry.buffer)
+			{
+				// Seek to the position of the next shader buffer to write.
+				fseek(f, static_cast<long>(bufferWriteOffset), SEEK_SET);
+				fwrite(entry.buffer, sizeof(char), entry.size, f);
+
+				// Buffer offsets are relative to the start of the desc structure, so subtract one from the other.
+				desc.u_standard.bufferOffset = static_cast<unsigned int>(bufferWriteOffset - thisDescOffset);
+				desc.u_standard.bufferLength = entry.size;
+
+				bufferWriteOffset += entry.size;
+			}
+			else if (entry.refIndex != UINT16_MAX) // If the ref index is not 0xFFFF, this entry is a reference.
+			{
+				desc.u_ref.bufferIndex = entry.refIndex;
+			}
+			else // If there is no valid buffer and no valid reference, this is a null entry.
+			{
+				desc.u_ref.bufferIndex = UINT32_MAX;
+				desc.u_ref._reserved = UINT32_MAX;
+			}
+
+			// Seek back to the desc location so we can write it now that the buffer is in place 
+			fseek(f, static_cast<long>(thisDescOffset), SEEK_SET);
+			fwrite(&desc, sizeof(desc), 1, f);
+
+			entryIndex++;
+		}
+	}
+
+private:
+	MultiShaderWrapperFileType_e _fileType;
+	bool writtenAnything;
+
+	union
+	{
+		Shader_t* shader;
+		struct ShaderSet
+		{
+			Shader_t* pixelShader;
+			Shader_t* vertexShader;
+		} shaderSet;
+	} _storedShaders;
+};

--- a/src/public/rpak.h
+++ b/src/public/rpak.h
@@ -244,12 +244,24 @@ public:
 
 	void* header;
 
+	// Extra information about the asset that is made available to other assets when being created.
+	std::shared_ptr<void> _publicData;
+
 	// vector of indexes for local assets that use this asset
 	std::vector<unsigned int> _relations{};
 
 	std::vector<PakGuidRefHdr_t> _guids{};
 
 	FORCEINLINE void SetHeaderPointer(void* pHeader) { this->header = pHeader; };
+
+	template <typename T>
+	inline void SetPublicData(T* const data)
+	{
+		std::shared_ptr<T> ptr(data);
+		_publicData = std::move(ptr);
+	}
+
+	char* const PublicData() { return reinterpret_cast<char*>(_publicData.get()); };
 
 	FORCEINLINE void AddRelation(unsigned int idx) { _relations.push_back({ idx }); };
 	FORCEINLINE void AddRelation(size_t idx) { _relations.push_back({ static_cast<unsigned int>(idx) }); };

--- a/src/public/rpak.h
+++ b/src/public/rpak.h
@@ -283,7 +283,13 @@ public:
 	{
 		if (!IsType(type))
 		{
-			Error("Unexpected asset type for '%s'. Expected '%.4s', found '%.4s'\n", this->name.c_str(), reinterpret_cast<char*>(&type), reinterpret_cast<char*>(&this->id));
+			Utils::FourCCString_t expected;
+			Utils::FourCCString_t found;
+
+			Utils::FourCCToString(expected, type);
+			Utils::FourCCToString(found, type);
+
+			Error("Unexpected asset type for '%s'. Expected '%.4s', found '%.4s'\n", this->name.c_str(), expected, found);
 		}
 	}
 };

--- a/src/public/shader.h
+++ b/src/public/shader.h
@@ -57,7 +57,7 @@ struct ShaderAssetHeader_v12_t
     PagePtr_t name; // const char*
     eShaderType type;
 
-    char unk_9[7];
+    char shaderFeatures[7];
 
     PagePtr_t unk_10; // void*
     PagePtr_t shaderInputFlags; // int64*
@@ -69,3 +69,5 @@ struct ShaderByteCode_t
     uint32_t dataSize;
     uint32_t unk;
 };
+
+static_assert(sizeof(ShaderByteCode_t) == 0x10);

--- a/src/public/shader.h
+++ b/src/public/shader.h
@@ -67,7 +67,12 @@ struct ShaderByteCode_t
 {
     PagePtr_t data;
     uint32_t dataSize;
+
     uint32_t unk;
+
+    // only exists in vertex shaders. shader writing code handles this by forcing the size to be 16 bytes (instead of 24)
+    // on non-vertex shaders
+    PagePtr_t inputSignatureBlob;
 };
 
-static_assert(sizeof(ShaderByteCode_t) == 0x10);
+static_assert(sizeof(ShaderByteCode_t) == 0x18);

--- a/src/public/shader.h
+++ b/src/public/shader.h
@@ -52,6 +52,17 @@ struct ShaderAssetHeader_v8_t
     PagePtr_t shaderInputFlags; // int64*
 };
 
+struct ShaderAssetHeader_v12_t
+{
+    PagePtr_t name; // const char*
+    eShaderType type;
+
+    char unk_9[7];
+
+    PagePtr_t unk_10; // void*
+    PagePtr_t shaderInputFlags; // int64*
+};
+
 struct ShaderByteCode_t
 {
     PagePtr_t data;

--- a/src/public/shaderset.h
+++ b/src/public/shaderset.h
@@ -3,26 +3,46 @@
 
 struct ShaderSetAssetHeader_v8_t
 {
-	uint64_t reservedVtbl;
+	uint64_t reserved_vftable;
 
 	PagePtr_t name; // const char*
 
-	uint64_t unk_10; // unknown data type, but definitely 8 bytes
+	uint64_t reserved_inputFlags; // unknown data type, but definitely 8 bytes
 
-	uint16_t unk_18; // count
+	uint16_t textureInputCounts[2];
 
-	uint16_t textureInputCount;
+	uint16_t numSamplers; // number of samplers used by the pixel shader
 
-	uint16_t samplerCount; // number of samplers used by the pixel shader
+	uint16_t firstResourceBindPoint;
+	uint16_t numResources;
 
-	uint8_t unk_1E;
-	uint8_t unk_1F;
-
-	uint8_t unk_20[40];
+	uint8_t unk_20[32];
 
 	uint64_t vertexShader;
 	uint64_t pixelShader;
 };
-static_assert(offsetof(ShaderSetAssetHeader_v8_t, vertexShader) == 72);
-static_assert(offsetof(ShaderSetAssetHeader_v8_t, unk_1E) == 0x1e);
 static_assert(sizeof(ShaderSetAssetHeader_v8_t) == 88);
+static_assert(offsetof(ShaderSetAssetHeader_v8_t, vertexShader) == 72);
+
+struct ShaderSetAssetHeader_v11_t
+{
+	uint64_t reserved_vftable;
+
+	PagePtr_t name; // const char*
+
+	uint64_t reserved_inputFlags; // stores some calculated value of vertex shader input flags
+
+	uint16_t textureInputCounts[2];
+
+	uint16_t numSamplers; // number of samplers used by the pixel shader
+
+	uint8_t firstResourceBindPoint;
+	uint8_t numResources;
+
+	uint8_t unk_20[16]; // at least some of this is reserved, potentially all of it
+
+	uint64_t vertexShader;
+	uint64_t pixelShader;
+};
+static_assert(sizeof(ShaderSetAssetHeader_v11_t) == 64);
+static_assert(offsetof(ShaderSetAssetHeader_v11_t, vertexShader) == 48);

--- a/src/utils/dxutils.cpp
+++ b/src/utils/dxutils.cpp
@@ -85,6 +85,8 @@ DXGI_FORMAT DXUtils::GetFormatFromHeaderEx(const DDS_HEADER& hdr)
 			if (pf.dwABitMask == 0xff)
 				return DXGI_FORMAT_A8_UNORM;
 		}
+		else if (pf.dwRBitMask == 0xff)
+			return DXGI_FORMAT_R8_UNORM;
 	}
 
 	// unsupported
@@ -236,6 +238,8 @@ bool DXUtils::GetParsedShaderData(const char* bytecode, size_t /*bytecodeLen*/, 
 	if (!outData)
 		return false;
 
+	outData->numTextureResources = 0;
+	outData->mtlTexSlotCount = 0;
 	for (uint32_t i = 0; i < fileHeader->BlobCount; ++i)
 	{
 		const DXBCBlobHeader* blob = fileHeader->pBlob(i);
@@ -244,7 +248,8 @@ bool DXUtils::GetParsedShaderData(const char* bytecode, size_t /*bytecodeLen*/, 
 		{
 			outData->EnableFlag(SHDR_FOUND_RDEF);
 
-			const RDEFBlobHeader* rdef = reinterpret_cast<const RDEFBlobHeader*>(blob->GetBlobData());
+			const RDefBlobHeader_t* rdef = reinterpret_cast<const RDefBlobHeader_t*>(blob->GetBlobData());
+			Debug("Shader built by \"%s\"\n", rdef->compilerName());
 
 			switch (rdef->ShaderType)
 			{
@@ -269,6 +274,20 @@ bool DXUtils::GetParsedShaderData(const char* bytecode, size_t /*bytecodeLen*/, 
 			default:
 				Error("Unknown shader type: %X\n", rdef->ShaderType);
 				break;
+			}
+
+			for (uint32_t j = 0; j < rdef->BoundResourceCount; ++j)
+			{
+				const RDefResourceBinding_t* resource = rdef->resource(j);
+				//printf("%s %s (%X)\n", resource->dimensionName(), resource->name(blob->GetBlobData()), resource->Flags);
+
+				if (resource->Type == D3D_SHADER_INPUT_TYPE::D3D_SIT_TEXTURE)
+				{
+					outData->numTextureResources++;
+
+					if (resource->BindPoint < 40)
+						outData->mtlTexSlotCount = static_cast<uint8_t>(resource->BindPoint) + 1;
+				}
 			}
 		}
 	}

--- a/src/utils/dxutils.cpp
+++ b/src/utils/dxutils.cpp
@@ -288,6 +288,9 @@ bool DXUtils::GetParsedShaderData(const char* bytecode, size_t /*bytecodeLen*/, 
 					if (resource->BindPoint < 40)
 						outData->mtlTexSlotCount = static_cast<uint8_t>(resource->BindPoint) + 1;
 				}
+
+				if (outData->numTextureResources > 0 && resource->Type != D3D_SHADER_INPUT_TYPE::D3D_SIT_TEXTURE)
+					break;
 			}
 		}
 	}

--- a/src/utils/dxutils.h
+++ b/src/utils/dxutils.h
@@ -110,7 +110,40 @@ typedef struct DXBCHeader
 
 } DXBCHeader;
 
-struct RDEFBlobHeader
+static const char* s_SRVDimensionNames[] = {
+	"UNKNOWN",
+	"Buffer",
+	"Texture1D",
+	"Texture1DArray",
+	"Texture2D",
+	"Texture2DArray",
+	"Texture2DMS",
+	"Texture2DMSArray",
+	"Texture3D",
+	"Texture3DArray",
+	"Texture3DCube",
+	"Texture3DCubeArray",
+	"BufferEx",
+};
+
+
+struct RDefResourceBinding_t
+{
+	uint32_t NameOffset; // from start of RDEFBlobHeader
+	D3D_SHADER_INPUT_TYPE Type;
+	D3D_RESOURCE_RETURN_TYPE ReturnType;
+	D3D10_SRV_DIMENSION Dimension;
+	uint32_t NumSamples;
+	uint32_t BindPoint;
+	uint32_t BindCount;
+	D3D_SHADER_INPUT_FLAGS Flags;
+
+	inline const char* name(void* rdefBlob) const { return reinterpret_cast<const char*>((char*)rdefBlob + NameOffset); }
+
+	inline const char* dimensionName() const { return s_SRVDimensionNames[Dimension]; };
+};
+
+struct RDefBlobHeader_t
 {
 	uint32_t ConstBufferCount;
 	uint32_t ConstBufferOffset;
@@ -123,6 +156,9 @@ struct RDEFBlobHeader
 	uint32_t CreatorOffset; // name of compiler?
 	uint32_t ID; // 'RD11'
 	uint32_t unk_20[7];
+
+	const RDefResourceBinding_t* const resource(uint32_t i) const { return reinterpret_cast<const RDefResourceBinding_t*>((char*)this + BoundResourceOffset) + i; };
+	const char* const compilerName() const { return reinterpret_cast<const char*>(this) + CreatorOffset; };
 };
 
 
@@ -130,7 +166,9 @@ struct RDEFBlobHeader
 struct ParsedDXShaderData_t
 {
 	UINT foundFlags;
+	int numTextureResources;
 	uint8_t pakShaderType; // eShaderType
+	uint8_t mtlTexSlotCount; // bind point for the last material-provided texture
 
 	void EnableFlag(UINT flag) { foundFlags |= flag; };
 };

--- a/src/utils/jsonutils.cpp
+++ b/src/utils/jsonutils.cpp
@@ -1,0 +1,19 @@
+//===========================================================================//
+//
+// Purpose: A set of utilities for RapidJSON
+//
+//===========================================================================//
+#include "pch.h"
+#include "jsonutils.h"
+
+//-----------------------------------------------------------------------------
+// Purpose: dumping a json document to a string buffer.
+//-----------------------------------------------------------------------------
+void JSON_DocumentToBufferDeserialize(const rapidjson::Document& document, rapidjson::StringBuffer& buffer, unsigned int indent)
+{
+    rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(buffer);
+
+    writer.SetIndent(' ', indent);
+    document.Accept(writer);
+}
+

--- a/src/utils/jsonutils.h
+++ b/src/utils/jsonutils.h
@@ -1,0 +1,172 @@
+//===========================================================================//
+//
+// Purpose: A set of utilities for RapidJSON
+//
+//===========================================================================//
+#ifndef JSONUTILS_H
+#define JSONUTILS_H
+
+//-----------------------------------------------------------------------------
+// JSON member enumerations
+//-----------------------------------------------------------------------------
+enum class JSONFieldType_e
+{
+    kNull = 0,
+    kObject,
+
+    kBool,
+    kNumber,
+
+    kSint32,
+    kUint32,
+
+    kSint64,
+    kUint64,
+
+    kFloat,
+    kLFloat,
+
+    kDouble,
+    kLDouble,
+
+    kString,
+    kArray
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: gets the object type as string
+//-----------------------------------------------------------------------------
+inline const char* JSON_TypeToString(const rapidjson::Type type)
+{
+    switch (type)
+    {
+    case rapidjson::kNullType: return "null";
+    case rapidjson::kFalseType: case rapidjson::kTrueType: return "bool";
+    case rapidjson::kObjectType: return "object";
+    case rapidjson::kArrayType: return "array";
+    case rapidjson::kStringType: return "string";
+    case rapidjson::kNumberType: return "number";
+    default: return "unknown";
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: checks if the member's value is of type provided
+//-----------------------------------------------------------------------------
+template <class T>
+inline bool JSON_IsOfType(const T& data, const JSONFieldType_e type)
+{
+    switch (type)
+    {
+    case JSONFieldType_e::kNull:
+        return data.IsNull();
+    case JSONFieldType_e::kObject:
+        return data.IsObject();
+    case JSONFieldType_e::kBool:
+        return data.IsBool();
+    case JSONFieldType_e::kNumber:
+        return data.IsNumber();
+    case JSONFieldType_e::kSint32:
+        return data.IsInt();
+    case JSONFieldType_e::kUint32:
+        return data.IsUint();
+    case JSONFieldType_e::kSint64:
+        return data.IsInt64();
+    case JSONFieldType_e::kUint64:
+        return data.IsUint64();
+    case JSONFieldType_e::kFloat:
+        return data.IsFloat();
+    case JSONFieldType_e::kLFloat:
+        return data.IsLosslessFloat();
+    case JSONFieldType_e::kDouble:
+        return data.IsDouble();
+    case JSONFieldType_e::kLDouble:
+        return data.IsLosslessDouble();
+    case JSONFieldType_e::kString:
+        return data.IsString();
+    case JSONFieldType_e::kArray:
+        return data.IsArray();
+    default:
+        return false;
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: checks if the member exists and if its value is of type provided
+//-----------------------------------------------------------------------------
+template <class T>
+inline bool JSON_HasMemberAndIsOfType(const T& data, const char* const member, const JSONFieldType_e type)
+{
+    const T::ConstMemberIterator it = data.FindMember(member);
+
+    if (it != data.MemberEnd())
+    {
+        return JSON_IsOfType(it->value, type);
+    }
+
+    return false;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: checks if the member exists and if its value is of type provided,
+// and sets 'out' to its value if all aforementioned conditions are met
+//-----------------------------------------------------------------------------
+template <class T, class V>
+inline bool JSON_GetValue(const T& data, const char* const member, const JSONFieldType_e type, V& out)
+{
+    const T::ConstMemberIterator it = data.FindMember(member);
+
+    if (it != data.MemberEnd())
+    {
+        const rapidjson::Value& val = it->value;
+
+        if (JSON_IsOfType(val, type))
+        {
+            out = val.Get<V>();
+            return true;
+        }
+    }
+
+    // Not found or didn't match specified type.
+    return false;
+}
+template <class T>
+inline bool JSON_GetValue(const T& data, const char* const member, const JSONFieldType_e type, std::string& out)
+{
+    const char* stringVal = nullptr;
+
+    if (JSON_GetValue(data, member, type, stringVal))
+    {
+        out = stringVal;
+        return true;
+    }
+
+    return false;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: checks if the member exists and if its value is of type provided,
+// and sets 'out' to its iterator if all aforementioned conditions are met
+//-----------------------------------------------------------------------------
+template <class T>
+inline bool JSON_GetIterator(const T& data, const char* const member,
+    const JSONFieldType_e type, typename T::ConstMemberIterator& out)
+{
+    const T::ConstMemberIterator it = data.FindMember(member);
+
+    if (it != data.MemberEnd())
+    {
+        if (JSON_IsOfType(it->value, type))
+        {
+            out = it;
+            return true;
+        }
+    }
+
+    // Not found or didn't match specified type.
+    return false;
+}
+
+void JSON_DocumentToBufferDeserialize(const rapidjson::Document& document, rapidjson::StringBuffer& buffer, unsigned int indent = 4);
+
+#endif // JSONUTILS_H

--- a/src/utils/jsonutils.h
+++ b/src/utils/jsonutils.h
@@ -167,6 +167,25 @@ inline bool JSON_GetIterator(const T& data, const char* const member,
     return false;
 }
 
+//-----------------------------------------------------------------------------
+// Purpose: checks if the member exists, and sets 'out' to its iterator if the
+// aforementioned condition is met
+//-----------------------------------------------------------------------------
+template <class T>
+inline bool JSON_GetIterator(const T& data, const char* const member, typename T::ConstMemberIterator& out)
+{
+    const T::ConstMemberIterator it = data.FindMember(member);
+
+    if (it != data.MemberEnd())
+    {
+        out = it;
+        return true;
+    }
+
+    // Not found.
+    return false;
+}
+
 void JSON_DocumentToBufferDeserialize(const rapidjson::Document& document, rapidjson::StringBuffer& buffer, unsigned int indent = 4);
 
 #endif // JSONUTILS_H

--- a/src/utils/strutils.cpp
+++ b/src/utils/strutils.cpp
@@ -1,0 +1,62 @@
+#include "pch.h"
+#include "strutils.h"
+
+std::vector<std::string> Utils::StringSplit(std::string input, const char delim, const size_t max)
+{
+    std::string subString;
+    std::vector<string> subStrings;
+
+    input = input + delim;
+
+    for (size_t i = 0; i < input.size(); i++)
+    {
+        if ((i != (input.size() - 1) && subStrings.size() >= max)
+            || input[i] != delim)
+        {
+            subString += input[i];
+        }
+        else
+        {
+            if (subString.size() != 0)
+            {
+                subStrings.push_back(subString);
+            }
+
+            subString.clear();
+        }
+    }
+
+    return subStrings;
+}
+
+// purpose: formats a standard string with printf like syntax (see 'https://stackoverflow.com/a/49812018')
+const std::string Utils::VFormat(const char* const zcFormat, ...)
+{
+    // initialize use of the variable argument array
+    va_list vaArgs;
+    va_start(vaArgs, zcFormat);
+
+    // reliably acquire the size
+    // from a copy of the variable argument array
+    // and a functionally reliable call to mock the formatting
+    va_list vaArgsCopy;
+    va_copy(vaArgsCopy, vaArgs);
+    const int iLen = std::vsnprintf(NULL, 0, zcFormat, vaArgsCopy);
+    va_end(vaArgsCopy);
+
+    // return a formatted string without risking memory mismanagement
+    // and without assuming any compiler or platform specific behavior
+    std::vector<char> zc(iLen + 1);
+    std::vsnprintf(zc.data(), zc.size(), zcFormat, vaArgs);
+    va_end(vaArgs);
+    return std::string(zc.data(), iLen);
+}
+
+void Utils::FourCCToString(FourCCString_t& buf, const unsigned int n)
+{
+    buf[0] = (char)((n & 0x000000ff) >> 0);
+    buf[1] = (char)((n & 0x0000ff00) >> 8);
+    buf[2] = (char)((n & 0x00ff0000) >> 16);
+    buf[3] = (char)((n & 0xff000000) >> 24);
+    buf[4] = '\0';
+};

--- a/src/utils/strutils.h
+++ b/src/utils/strutils.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace Utils
+{
+	typedef char FourCCString_t[5];
+	void FourCCToString(FourCCString_t& buf, const unsigned int n);
+
+	std::vector<std::string> StringSplit(std::string input, const char delim, const size_t max = SIZE_MAX);
+	const std::string VFormat(const char* const zcFormat, ...);
+};

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -135,29 +135,3 @@ void Utils::ParseMapDocument(js::Document& doc, const fs::path& path)
             lastLine.c_str(), curLine.c_str(), (std::string(columnNum, ' ') += '^').c_str());
     }
 }
-
-//-----------------------------------------------------------------------------
-// purpose: formats a standard string with printf like syntax (see 'https://stackoverflow.com/a/49812018')
-//-----------------------------------------------------------------------------
-const std::string Utils::VFormat(const char* const zcFormat, ...)
-{
-
-    // initialize use of the variable argument array
-    va_list vaArgs;
-    va_start(vaArgs, zcFormat);
-
-    // reliably acquire the size
-    // from a copy of the variable argument array
-    // and a functionally reliable call to mock the formatting
-    va_list vaArgsCopy;
-    va_copy(vaArgsCopy, vaArgs);
-    const int iLen = std::vsnprintf(NULL, 0, zcFormat, vaArgsCopy);
-    va_end(vaArgsCopy);
-
-    // return a formatted string without risking memory mismanagement
-    // and without assuming any compiler or platform specific behavior
-    std::vector<char> zc(iLen + 1);
-    std::vsnprintf(zc.data(), zc.size(), zcFormat, vaArgs);
-    va_end(vaArgs);
-    return std::string(zc.data(), iLen);
-}

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -12,8 +12,6 @@ namespace Utils
 	std::string ChangeExtension(const std::string& in, const std::string& ext);
 
 	void ParseMapDocument(js::Document& doc, const fs::path& path);
-
-	const std::string VFormat(const char* const zcFormat, ...);
 };
 
 using namespace std::chrono;
@@ -70,6 +68,7 @@ private:
 #define MAKE_FOURCC(a,b,c,d) ((d<<24)+(c<<16)+(b<<8)+a)
 
 // json helper macros
+// todo: move to jsonutils.h and reuse cache iterator
 #define JSON_IS_BOOL(doc, name) (doc.HasMember(name) && doc[name].IsBool())
 #define JSON_IS_INT64(doc, name) (doc.HasMember(name) && doc[name].IsInt64())
 #define JSON_IS_UINT64(doc, name) (doc.HasMember(name) && doc[name].IsUint64())


### PR DESCRIPTION
Implements shader packing and blend state parsing

* Assets of type 'shdr' (Shader) and 'shds' (Shader Set) can now be package into the RPak file.
* Blend states can now be parsed out of the material objects, from the 'blendStates' field. Supported input is an array of blend states (either hex string or uint32), or a space separated string with hex values. The array must always contain 8 elements for Apex paks and 4 for Titanfall 2 paks.