### PR TITLE
Per pak compress options

### DIFF
--- a/src/assets/settings.cpp
+++ b/src/assets/settings.cpp
@@ -49,7 +49,7 @@ static JSONFieldType_e GetJsonMemberTypeForSettingsType(const SettingsFieldType_
     case SettingsFieldType_e::ST_Float3:
     case SettingsFieldType_e::ST_String:
     case SettingsFieldType_e::ST_Asset:
-    case SettingsFieldType_e::ST_Asset_2:
+    case SettingsFieldType_e::ST_AssetNoPrecache:
         return JSONFieldType_e::kString;
 
     case SettingsFieldType_e::ST_StaticArray:
@@ -397,7 +397,7 @@ static void SettingsAsset_CalculateModValuesBuffers(const rapidjson::Value& modV
             // of type string, so it can match any of these.
             if (fieldTypeExpected != SettingsFieldType_e::ST_String &&
                 fieldTypeExpected != SettingsFieldType_e::ST_Asset &&
-                fieldTypeExpected != SettingsFieldType_e::ST_Asset_2)
+                fieldTypeExpected != SettingsFieldType_e::ST_AssetNoPrecache)
             {
                 fieldTypeMismatch = true;
             }
@@ -505,7 +505,7 @@ static void SettingsAsset_WriteValues(const SettingsLayoutAsset_s& layoutAsset, 
             SettingsAsset_WriteAssetValue(it.value.GetString(), it.value.GetStringLength(), targetOffset, asset, pak, dataLump, settingsMemory);
             break;
         case SettingsFieldType_e::ST_String:
-        case SettingsFieldType_e::ST_Asset_2:
+        case SettingsFieldType_e::ST_AssetNoPrecache:
             SettingsAsset_WriteStringValue(it.value.GetString(), it.value.GetStringLength(), targetOffset, pak, dataLump, settingsMemory);
             break;
         case SettingsFieldType_e::ST_StaticArray:

--- a/src/assets/settings.cpp
+++ b/src/assets/settings.cpp
@@ -355,8 +355,8 @@ static void SettingsAsset_CalculateModValuesBuffers(const rapidjson::Value& modV
             if (!JSON_ParseNumber(fieldDescIt->value, targetOffset))
                 Error("Settings mod value #%zu has an invalid offset.\n", elemIndex);
 
-            if (!SettingsLayout_FindFieldByAbsoluteOffset(layout, targetOffset, findByOffset))
-                Error("Settings mod value #%zu has an offset of %u which doesn't map to a field in the given settings layout.\n", elemIndex, targetOffset);
+            if (!SettingsFieldFinder_FindFieldByAbsoluteOffset(layout, targetOffset, findByOffset))
+                Error("Settings mod value #%zu has an absolute offset of %u which doesn't map to a field in the given settings layout.\n", elemIndex, targetOffset);
 
             targetFieldName = findByOffset.fieldAccessPath.c_str();
             fieldTypeExpected = findByOffset.type;

--- a/src/assets/settings.cpp
+++ b/src/assets/settings.cpp
@@ -370,14 +370,16 @@ static void SettingsAsset_CalculateModValuesBuffers(const rapidjson::Value& modV
 
         if (isNumericType)
         {
-            if (fieldTypeExpected == SettingsFieldType_e::ST_Int && fieldTypeRequested != SettingsFieldType_e::ST_Int)
+            if (fieldTypeExpected == SettingsFieldType_e::ST_Int)
             {
-                fieldTypeMismatch = true;
+                fieldTypeMismatch = fieldTypeRequested != SettingsFieldType_e::ST_Int;
             }
-            else if (fieldTypeExpected == SettingsFieldType_e::ST_Float && fieldTypeRequested != SettingsFieldType_e::ST_Float)
+            else if (fieldTypeExpected == SettingsFieldType_e::ST_Float)
             {
-                fieldTypeMismatch = true;
+                fieldTypeMismatch = fieldTypeRequested != SettingsFieldType_e::ST_Float;
             }
+            else
+                fieldTypeMismatch = true; // Not a numeric type.
         }
         else if (isStringType)
         {

--- a/src/assets/settings.cpp
+++ b/src/assets/settings.cpp
@@ -355,7 +355,7 @@ static void SettingsAsset_CalculateModValuesBuffers(const rapidjson::Value& modV
             if (!JSON_ParseNumber(fieldDescIt->value, targetOffset))
                 Error("Settings mod value #%zu has an invalid offset.\n", elemIndex);
 
-            if (!SettingsLayout_FindFieldByOffset(layout, targetOffset, findByOffset))
+            if (!SettingsLayout_FindFieldByAbsoluteOffset(layout, targetOffset, findByOffset))
                 Error("Settings mod value #%zu has an offset of %u which doesn't map to a field in the given settings layout.\n", elemIndex, targetOffset);
 
             targetFieldName = findByOffset.fieldAccessPath.c_str();

--- a/src/assets/settings.cpp
+++ b/src/assets/settings.cpp
@@ -345,6 +345,8 @@ static void SettingsAsset_CalculateModValuesBuffers(const rapidjson::Value& modV
         const char* targetFieldName;
         SettingsFieldType_e fieldTypeExpected;
 
+        SettingsLayoutFindByOffsetResult_s findByOffset;
+
         rapidjson::Value::ConstMemberIterator fieldDescIt;
         if (JSON_GetIterator(elem, "offset", fieldDescIt)) // Use offset instead of field names if available.
         {
@@ -353,13 +355,11 @@ static void SettingsAsset_CalculateModValuesBuffers(const rapidjson::Value& modV
             if (!JSON_ParseNumber(fieldDescIt->value, targetOffset))
                 Error("Settings mod value #%zu has an invalid offset.\n", elemIndex);
 
-            SettingsLayoutFindByOffsetResult_s searchResult;
-
-            if (!SettingsLayout_FindFieldByOffset(layout, targetOffset, searchResult))
+            if (!SettingsLayout_FindFieldByOffset(layout, targetOffset, findByOffset))
                 Error("Settings mod value #%zu has an offset of %u which doesn't map to a field in the given settings layout.\n", elemIndex, targetOffset);
 
-            targetFieldName = searchResult.name;
-            fieldTypeExpected = searchResult.type;
+            targetFieldName = findByOffset.fieldAccessPath.c_str();
+            fieldTypeExpected = findByOffset.type;
 
             cache.valueOffset = targetOffset;
         }

--- a/src/assets/settings_layout.cpp
+++ b/src/assets/settings_layout.cpp
@@ -64,7 +64,7 @@ SettingsFieldType_e SettingsLayout_GetFieldTypeForString(const char* const typeN
     return SettingsFieldType_e::ST_Invalid;
 }
 
-bool SettingsLayout_FindFieldByOffset(const SettingsLayoutAsset_s& layout, const uint32_t targetOffset, SettingsLayoutFindByOffsetResult_s& result)
+bool SettingsLayout_FindFieldByAbsoluteOffset(const SettingsLayoutAsset_s& layout, const uint32_t targetOffset, SettingsLayoutFindByOffsetResult_s& result)
 {
     for (size_t i = 0; i < layout.rootLayout.typeMap.size(); i++)
     {
@@ -105,7 +105,7 @@ bool SettingsLayout_FindFieldByOffset(const SettingsLayoutAsset_s& layout, const
                 result.currentBase = IALIGN(absoluteFieldOffset, subLayout.rootLayout.alignment);
 
                 // Recurse into sub-layout for array elements.
-                if (SettingsLayout_FindFieldByOffset(subLayout, targetOffset, result))
+                if (SettingsLayout_FindFieldByAbsoluteOffset(subLayout, targetOffset, result))
                 {
                     result.fieldAccessPath.insert(0, Utils::VFormat("%s[%zu].", layout.rootLayout.fieldNames[i].c_str(), currArrayIdx));
                     return true;

--- a/src/assets/settings_layout.cpp
+++ b/src/assets/settings_layout.cpp
@@ -69,7 +69,6 @@ bool SettingsFieldFinder_FindFieldByAbsoluteOffset(const SettingsLayoutAsset_s& 
     for (size_t i = 0; i < layout.rootLayout.typeMap.size(); i++)
     {
         const uint32_t totalValueBufSizeAligned = IALIGN(layout.rootLayout.totalValueBufferSize, layout.rootLayout.alignment);
-        const uint32_t originalBase = result.currentBase;
 
         if (targetOffset > result.currentBase + (layout.rootLayout.arrayElemCount * totalValueBufSizeAligned))
             return false; // Beyond this layout.
@@ -78,6 +77,8 @@ bool SettingsFieldFinder_FindFieldByAbsoluteOffset(const SettingsLayoutAsset_s& 
 
         if (targetOffset < fieldOffset)
             return false; // Invalid offset (i.e. we have 2 ints at 4 and 8, but target was 5).
+
+        const uint32_t originalBase = result.currentBase;
 
         for (int currArrayIdx = 0; currArrayIdx < layout.rootLayout.arrayElemCount; currArrayIdx++)
         {

--- a/src/assets/settings_layout.cpp
+++ b/src/assets/settings_layout.cpp
@@ -89,7 +89,7 @@ bool SettingsLayout_FindFieldByOffset(const SettingsLayoutAsset_s& layout, const
                 // note(amos): we use `i` here instead of `currArrayIdx`
                 //             because array fields descriptors are only
                 //             stored once in a given layout.
-                result.name = layout.rootLayout.fieldNames[i].c_str();
+                result.fieldAccessPath.insert(0, layout.rootLayout.fieldNames[i]);
                 result.type = layout.rootLayout.typeMap[i];
 
                 return true;
@@ -106,7 +106,10 @@ bool SettingsLayout_FindFieldByOffset(const SettingsLayoutAsset_s& layout, const
 
                 // Recurse into sub-layout for array elements.
                 if (SettingsLayout_FindFieldByOffset(subLayout, targetOffset, result))
+                {
+                    result.fieldAccessPath.insert(0, Utils::VFormat("%s[%zu].", layout.rootLayout.fieldNames[i].c_str(), currArrayIdx));
                     return true;
+                }
 
                 result.currentBase = originalBase;
             }

--- a/src/assets/settings_layout.cpp
+++ b/src/assets/settings_layout.cpp
@@ -22,7 +22,7 @@ uint32_t SettingsLayout_GetFieldSizeForType(const SettingsFieldType_e type)
         return sizeof(float) * 3;
     case SettingsFieldType_e::ST_String:
     case SettingsFieldType_e::ST_Asset:
-    case SettingsFieldType_e::ST_Asset_2:
+    case SettingsFieldType_e::ST_AssetNoPrecache:
         return sizeof(PagePtr_t);
     case SettingsFieldType_e::ST_DynamicArray:
         return sizeof(SettingsDynamicArray_s);
@@ -46,7 +46,7 @@ uint32_t SettingsLayout_GetFieldAlignmentForType(const SettingsFieldType_e type)
         return sizeof(float);
     case SettingsFieldType_e::ST_String:
     case SettingsFieldType_e::ST_Asset:
-    case SettingsFieldType_e::ST_Asset_2:
+    case SettingsFieldType_e::ST_AssetNoPrecache:
         return sizeof(void*);
 
     default: assert(0); return 0;

--- a/src/assets/settings_layout.cpp
+++ b/src/assets/settings_layout.cpp
@@ -185,6 +185,13 @@ static void SettingsLayout_ParseTable(CPakFileBuilder* const pak, const char* co
         Error("Failed to open settings layout table \"%s\".\n", settingsLayoutFile.c_str());
 
     rapidcsv::Document document(datatableStream);
+    const size_t columnCount = document.GetColumnCount();
+
+    // Rows: fieldName, dataType, layoutIndex, helpText.
+    constexpr size_t expectedColumnCount = 4;
+
+    if (columnCount != expectedColumnCount)
+        Error("Settings layout table \"%s\" has %zu columns, but %zu were expected.\n", settingsLayoutFile.c_str(), columnCount, expectedColumnCount);
 
     result.fieldNames = document.GetColumn<std::string>(0);
     const size_t numFieldNames = result.fieldNames.size();

--- a/src/assets/settings_layout.cpp
+++ b/src/assets/settings_layout.cpp
@@ -92,6 +92,7 @@ bool SettingsFieldFinder_FindFieldByAbsoluteOffset(const SettingsLayoutAsset_s& 
                 //             stored once in a given layout.
                 result.fieldAccessPath.insert(0, layout.rootLayout.fieldNames[i]);
                 result.type = layout.rootLayout.typeMap[i];
+                result.lastArrayIdx = currArrayIdx;
 
                 return true;
             }
@@ -108,7 +109,9 @@ bool SettingsFieldFinder_FindFieldByAbsoluteOffset(const SettingsLayoutAsset_s& 
                 // Recurse into sub-layout for array elements.
                 if (SettingsFieldFinder_FindFieldByAbsoluteOffset(subLayout, targetOffset, result))
                 {
-                    result.fieldAccessPath.insert(0, Utils::VFormat("%s[%zu].", layout.rootLayout.fieldNames[i].c_str(), currArrayIdx));
+                    result.fieldAccessPath.insert(0, Utils::VFormat("%s[%i].", layout.rootLayout.fieldNames[i].c_str(), result.lastArrayIdx));
+                    result.lastArrayIdx = currArrayIdx;
+
                     return true;
                 }
 

--- a/src/assets/settings_layout.cpp
+++ b/src/assets/settings_layout.cpp
@@ -64,7 +64,7 @@ SettingsFieldType_e SettingsLayout_GetFieldTypeForString(const char* const typeN
     return SettingsFieldType_e::ST_Invalid;
 }
 
-bool SettingsLayout_FindFieldByAbsoluteOffset(const SettingsLayoutAsset_s& layout, const uint32_t targetOffset, SettingsLayoutFindByOffsetResult_s& result)
+bool SettingsFieldFinder_FindFieldByAbsoluteOffset(const SettingsLayoutAsset_s& layout, const uint32_t targetOffset, SettingsLayoutFindByOffsetResult_s& result)
 {
     for (size_t i = 0; i < layout.rootLayout.typeMap.size(); i++)
     {
@@ -105,7 +105,7 @@ bool SettingsLayout_FindFieldByAbsoluteOffset(const SettingsLayoutAsset_s& layou
                 result.currentBase = IALIGN(absoluteFieldOffset, subLayout.rootLayout.alignment);
 
                 // Recurse into sub-layout for array elements.
-                if (SettingsLayout_FindFieldByAbsoluteOffset(subLayout, targetOffset, result))
+                if (SettingsFieldFinder_FindFieldByAbsoluteOffset(subLayout, targetOffset, result))
                 {
                     result.fieldAccessPath.insert(0, Utils::VFormat("%s[%zu].", layout.rootLayout.fieldNames[i].c_str(), currArrayIdx));
                     return true;

--- a/src/logic/buildsettings.cpp
+++ b/src/logic/buildsettings.cpp
@@ -12,8 +12,6 @@ CBuildSettings::CBuildSettings()
 {
 	m_pakVersion = 0;
 	m_buildFlags = 0;
-	m_compressLevel = 0;
-	m_compressWorkers = 0;
 }
 
 void CBuildSettings::Init(const js::Document& doc, const char* const buildMapFile)
@@ -41,11 +39,6 @@ void CBuildSettings::Init(const js::Document& doc, const char* const buildMapFil
 
 	if (JSON_GetValueOrDefault(doc, "keepClientOnly", true))
 		AddFlags(PF_KEEP_CLIENT);
-
-	m_compressLevel = JSON_GetValueOrDefault(doc, "compressLevel", 0);
-
-	if (m_compressLevel > 0)
-		m_compressWorkers = JSON_GetValueOrDefault(doc, "compressWorkers", 0);
 
 	g_showDebugLogs = JSON_GetValueOrDefault(doc, "showDebugInfo", false);
 }

--- a/src/logic/buildsettings.h
+++ b/src/logic/buildsettings.h
@@ -15,15 +15,9 @@ public:
 	inline const char* GetBuildMapPath() const { return m_buildMapPath.c_str(); }
 	inline const char* GetOutputPath() const { return m_outputPath.c_str(); }
 
-	inline int GetCompressLevel() const { return m_compressLevel; }
-	inline int GetNumCompressWorkers() const { return m_compressWorkers; }
-
 private:
 	int m_pakVersion;
 	int m_buildFlags;
-
-	int m_compressLevel;
-	int m_compressWorkers;
 
 	std::string m_buildMapPath;
 	std::string m_outputPath;

--- a/src/logic/pakfile.cpp
+++ b/src/logic/pakfile.cpp
@@ -626,8 +626,8 @@ size_t CPakFileBuilder::EncodeStreamAndSwap(BinaryIO& io, const int compressLeve
 		Error("Reopened pak file \"%s\" appears truncated or corrupt; compressed size: %zu expected: %zu.\n",
 			m_pakFilePath.c_str(), reopenedPakSize, compressedSize);
 
-	// set the header flags indicating this pak is compressed.
-	m_Header.flags |= (PAK_HEADER_FLAGS_COMPRESSED | PAK_HEADER_FLAGS_ZSTREAM_ENCODED);
+	// set the header flags indicating this pak is compressed using zstandard.
+	m_Header.flags |= PAK_HEADER_FLAGS_ZSTD_ENCODED;
 
 	return compressedSize;
 }

--- a/src/logic/pakfile.cpp
+++ b/src/logic/pakfile.cpp
@@ -719,11 +719,11 @@ void CPakFileBuilder::BuildFromMap(const js::Document& doc)
 	const size_t decompressedFileSize = out.GetSize();
 	size_t compressedFileSize = 0;
 
-	const int compressLevel = m_buildSettings->GetCompressLevel();
+	const int compressLevel = JSON_GetValueOrDefault(doc, "compressLevel", 0);
 
 	if (compressLevel > 0 && decompressedFileSize > Pak_GetHeaderSize(m_Header.fileVersion))
 	{
-		const int workerCount = m_buildSettings->GetNumCompressWorkers();
+		const int workerCount = JSON_GetValueOrDefault(doc, "compressWorkers", 0);
 
 		Log("Encoding pak file with compress level %i and %i workers.\n", compressLevel, workerCount);
 		compressedFileSize = EncodeStreamAndSwap(out, compressLevel, workerCount);

--- a/src/public/rpak.h
+++ b/src/public/rpak.h
@@ -12,8 +12,8 @@
 #define RPAK_MAGIC (('k'<<24)+('a'<<16)+('P'<<8)+'R')
 #define RPAK_EXTENSION ".rpak"
 
-#define PAK_HEADER_FLAGS_COMPRESSED      (1<<8)
-#define PAK_HEADER_FLAGS_ZSTREAM_ENCODED (1<<9) // use the ZStd decoder instead of the RTech one
+#define PAK_HEADER_FLAGS_RTECH_ENCODED (1<<8) // use the RTech decoder in the runtime.
+#define PAK_HEADER_FLAGS_ZSTD_ENCODED  (1<<9) // use the ZStd decoder in the runtime.
 
 #define PAK_MAX_STEM_PATH 512
 

--- a/src/public/settings.h
+++ b/src/public/settings.h
@@ -1,6 +1,47 @@
 #pragma once
 //#include <pch.h>
 
+enum SettingsModType_e : unsigned short
+{
+	kIntPlus = 0x0,
+	kIntMultiply = 0x1,
+	kFloatPlus = 0x2,
+	kFloatMultiply = 0x3,
+	kBool = 0x4,
+	kNumber = 0x5,
+	kString = 0x6,
+
+	SETTINGS_MOD_COUNT
+};
+
+inline const char* const g_settingsModType[SETTINGS_MOD_COUNT] =
+{
+	"int_plus",
+	"int_multipy",
+	"float_plus",
+	"float_multipy",
+	"bool",
+	"number",
+	"string"
+};
+
+union SettingsModValue_u
+{
+	bool boolValue;
+	int intValue;
+	float floatValue;
+	uint32_t stringOffset;
+};
+
+struct SettingsMod_s
+{
+	unsigned char nameIndex; // Index into mod names array.
+	unsigned char pad;
+	SettingsModType_e type;
+	int valueOffset;
+	SettingsModValue_u value;
+};
+
 struct SettingsAssetHeader_s
 {
 	// This field becomes a pointer to the settings layout
@@ -13,16 +54,15 @@ struct SettingsAssetHeader_s
 	char* stringData;
 	uint32_t uniqueId;
 
-	char unk_24[4]; // padding most likely
+	char padding[4]; // padding most likely
 
 	const char** modNames;
-
-	void* unk_30;
+	SettingsMod_s* modValues;
 
 	uint32_t valueBufSize;
-	int unknown1;
+	uint32_t modCountSinglePlayer;
 	uint32_t modNameCount;
-	int unknown3;
+	uint32_t modValuesCount;
 };
 static_assert(sizeof(SettingsAssetHeader_s) == 72);
 

--- a/src/public/settings.h
+++ b/src/public/settings.h
@@ -1,5 +1,5 @@
 #pragma once
-//#include <pch.h>
+#define SETTINGS_MAX_MODS UINT16_MAX
 
 enum SettingsModType_e : unsigned short
 {
@@ -35,8 +35,7 @@ union SettingsModValue_u
 
 struct SettingsMod_s
 {
-	unsigned char nameIndex; // Index into mod names array.
-	unsigned char pad;
+	uint16_t nameIndex; // Index into mod names array.
 	SettingsModType_e type;
 	int valueOffset;
 	SettingsModValue_u value;

--- a/src/public/settings.h
+++ b/src/public/settings.h
@@ -60,7 +60,7 @@ struct SettingsAssetHeader_s
 	SettingsMod_s* modValues;
 
 	uint32_t valueBufSize;
-	uint32_t modCountSinglePlayer;
+	uint32_t modFlags;
 	uint32_t modNameCount;
 	uint32_t modValuesCount;
 };

--- a/src/public/settings_layout.h
+++ b/src/public/settings_layout.h
@@ -134,7 +134,7 @@ struct SettingsLayoutFindByOffsetResult_s
 
 	std::string fieldAccessPath;
 	SettingsFieldType_e type;
-	uint32_t currentBase;  // Only used by SettingsLayout_GetFieldForOffset internally.
+	uint32_t currentBase;  // Only used by SettingsLayout_FindFieldByAbsoluteOffset internally.
 };
 
-extern bool SettingsLayout_FindFieldByOffset(const SettingsLayoutAsset_s& layout, const uint32_t targetOffset, SettingsLayoutFindByOffsetResult_s& result);
+extern bool SettingsLayout_FindFieldByAbsoluteOffset(const SettingsLayoutAsset_s& layout, const uint32_t targetOffset, SettingsLayoutFindByOffsetResult_s& result);

--- a/src/public/settings_layout.h
+++ b/src/public/settings_layout.h
@@ -137,4 +137,4 @@ struct SettingsLayoutFindByOffsetResult_s
 	uint32_t currentBase;  // Only used by SettingsLayout_FindFieldByAbsoluteOffset internally.
 };
 
-extern bool SettingsLayout_FindFieldByAbsoluteOffset(const SettingsLayoutAsset_s& layout, const uint32_t targetOffset, SettingsLayoutFindByOffsetResult_s& result);
+extern bool SettingsFieldFinder_FindFieldByAbsoluteOffset(const SettingsLayoutAsset_s& layout, const uint32_t targetOffset, SettingsLayoutFindByOffsetResult_s& result);

--- a/src/public/settings_layout.h
+++ b/src/public/settings_layout.h
@@ -49,10 +49,9 @@ struct SettingsLayoutHeader_s
 	uint32_t hashStepScale;
 	uint32_t hashSeed;
 
-	// -1 on dynamic arrays?
-	int arrayElemCount;
+	int arrayElemCount; // Always -1 on dynamic arrays.
 	int layoutSize;
-	int unk_34; // seems unused, needs research, always 0, most likely padding.
+	int pad34; // seems unused, needs research, always 0, most likely padding.
 	PagePtr_t fieldNames;
 	PagePtr_t subHeaders; // points to an array of SettingsLayoutHeader_s
 };

--- a/src/public/settings_layout.h
+++ b/src/public/settings_layout.h
@@ -128,14 +128,13 @@ struct SettingsLayoutFindByOffsetResult_s
 {
 	SettingsLayoutFindByOffsetResult_s()
 	{
-		name = nullptr;
-		currentBase = 0;
 		type = SettingsFieldType_e::ST_Invalid;
+		currentBase = 0;
 	}
 
-	const char* name;
-	uint32_t currentBase; // Only used by SettingsLayout_GetFieldForOffset internally.
+	std::string fieldAccessPath;
 	SettingsFieldType_e type;
+	uint32_t currentBase;  // Only used by SettingsLayout_GetFieldForOffset internally.
 };
 
 extern bool SettingsLayout_FindFieldByOffset(const SettingsLayoutAsset_s& layout, const uint32_t targetOffset, SettingsLayoutFindByOffsetResult_s& result);

--- a/src/public/settings_layout.h
+++ b/src/public/settings_layout.h
@@ -139,3 +139,19 @@ struct SettingsLayoutFindByOffsetResult_s
 };
 
 extern bool SettingsFieldFinder_FindFieldByAbsoluteOffset(const SettingsLayoutAsset_s& layout, const uint32_t targetOffset, SettingsLayoutFindByOffsetResult_s& result);
+
+struct SettingsLayoutFindByNameResult_s
+{
+	SettingsLayoutFindByNameResult_s()
+	{
+		valueOffset = 0;
+		type = SettingsFieldType_e::ST_Invalid;
+		currentBase = 0;
+	}
+
+	uint32_t valueOffset;
+	SettingsFieldType_e type;
+	uint32_t currentBase;  // Only used by SettingsFieldFinder_FindFieldByAbsoluteName internally.
+};
+
+extern bool SettingsFieldFinder_FindFieldByAbsoluteName(const SettingsLayoutAsset_s& layout, const char* const targetName, SettingsLayoutFindByNameResult_s& result);

--- a/src/public/settings_layout.h
+++ b/src/public/settings_layout.h
@@ -130,11 +130,13 @@ struct SettingsLayoutFindByOffsetResult_s
 	{
 		type = SettingsFieldType_e::ST_Invalid;
 		currentBase = 0;
+		lastArrayIdx = 0;
 	}
 
 	std::string fieldAccessPath;
 	SettingsFieldType_e type;
-	uint32_t currentBase;  // Only used by SettingsLayout_FindFieldByAbsoluteOffset internally.
+	uint32_t currentBase;  // Only used by SettingsFieldFinder_FindFieldByAbsoluteOffset internally.
+	int lastArrayIdx;      // Only used by SettingsFieldFinder_FindFieldByAbsoluteOffset internally.
 };
 
 extern bool SettingsFieldFinder_FindFieldByAbsoluteOffset(const SettingsLayoutAsset_s& layout, const uint32_t targetOffset, SettingsLayoutFindByOffsetResult_s& result);

--- a/src/public/settings_layout.h
+++ b/src/public/settings_layout.h
@@ -138,4 +138,4 @@ struct SettingsLayoutFindByOffsetResult_s
 	SettingsFieldType_e type;
 };
 
-extern bool SettingsLayout_FindFieldByOffset(const SettingsLayoutAsset_s& layout, const uint32_t targetOffset, SettingsLayoutFindByOffsetResult_s& out);
+extern bool SettingsLayout_FindFieldByOffset(const SettingsLayoutAsset_s& layout, const uint32_t targetOffset, SettingsLayoutFindByOffsetResult_s& result);

--- a/src/public/settings_layout.h
+++ b/src/public/settings_layout.h
@@ -123,3 +123,19 @@ static const char* s_settingsFieldTypeNames[] = {
 extern uint32_t SettingsLayout_GetFieldSizeForType(const SettingsFieldType_e type);
 extern uint32_t SettingsLayout_GetFieldAlignmentForType(const SettingsFieldType_e type);
 extern SettingsFieldType_e SettingsLayout_GetFieldTypeForString(const char* const typeName);
+
+struct SettingsLayoutFindByOffsetResult_s
+{
+	SettingsLayoutFindByOffsetResult_s()
+	{
+		name = nullptr;
+		currentBase = 0;
+		type = SettingsFieldType_e::ST_Invalid;
+	}
+
+	const char* name;
+	uint32_t currentBase; // Only used by SettingsLayout_GetFieldForOffset internally.
+	SettingsFieldType_e type;
+};
+
+extern bool SettingsLayout_FindFieldByOffset(const SettingsLayoutAsset_s& layout, const uint32_t targetOffset, SettingsLayoutFindByOffsetResult_s& out);

--- a/src/public/settings_layout.h
+++ b/src/public/settings_layout.h
@@ -9,7 +9,7 @@ enum SettingsFieldType_e : unsigned short
 	ST_Float3,
 	ST_String,
 	ST_Asset,
-	ST_Asset_2,
+	ST_AssetNoPrecache,
 	ST_StaticArray,
 	ST_DynamicArray,
 

--- a/src/public/studio.h
+++ b/src/public/studio.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "math/vector.h"
+#include "material.h"
 
 #pragma pack(push, 1)
 // used for referencing a material from within a model
@@ -65,9 +66,9 @@ struct studiohdr_t
 		return reinterpret_cast<mstudiotexture_t*>((char*)this + textureindex) + i;
 	}
 
-	inline uint8_t materialType(int i)
+	inline MaterialShaderType_e materialType(int i)
 	{
-		return reinterpret_cast<uint8_t*>((char*)this + materialtypesindex)[i];
+		return reinterpret_cast<MaterialShaderType_e*>((char*)this + materialtypesindex)[i];
 	}
 
 	// this should always only be one, unless using vmts.


### PR DESCRIPTION
Allow to specify compression parameters individually instead of one for all. This is useful for paks that make no sense to compress (i.e. a 4KiB pak file).