### PR TITLE
Stream cache data deduplication bug fix

### DIFF
--- a/src/RePak.vcxproj
+++ b/src/RePak.vcxproj
@@ -17,6 +17,7 @@
     <ClCompile Include="assets\anim_recording.cpp" />
     <ClCompile Include="assets\datatable.cpp" />
     <ClCompile Include="assets\material.cpp" />
+    <ClCompile Include="assets\material_for_aspect.cpp" />
     <ClCompile Include="assets\model.cpp" />
     <ClCompile Include="assets\patch.cpp" />
     <ClCompile Include="assets\settings.cpp" />
@@ -187,6 +188,7 @@
     <ClInclude Include="public\anim_recording.h" />
     <ClInclude Include="public\material.h" />
     <ClInclude Include="public\materialflags.h" />
+    <ClInclude Include="public\material_for_aspect.h" />
     <ClInclude Include="public\multishader.h" />
     <ClInclude Include="public\rpak.h" />
     <ClInclude Include="public\settings.h" />

--- a/src/RePak.vcxproj
+++ b/src/RePak.vcxproj
@@ -166,6 +166,7 @@
     </ClCompile>
     <ClCompile Include="utils\strutils.cpp" />
     <ClCompile Include="utils\utils.cpp" />
+    <ClCompile Include="utils\zstdutils.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="assets\assets.h" />
@@ -283,6 +284,7 @@
     <ClInclude Include="utils\MurmurHash3.h" />
     <ClInclude Include="utils\strutils.h" />
     <ClInclude Include="utils\utils.h" />
+    <ClInclude Include="utils\zstdutils.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="cpp.hint" />

--- a/src/RePak.vcxproj.filters
+++ b/src/RePak.vcxproj.filters
@@ -237,6 +237,9 @@
     <ClCompile Include="assets\anim_recording.cpp">
       <Filter>assets</Filter>
     </ClCompile>
+    <ClCompile Include="utils\zstdutils.cpp">
+      <Filter>utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="assets\assets.h">
@@ -583,6 +586,9 @@
     </ClInclude>
     <ClInclude Include="public\anim_recording.h">
       <Filter>public</Filter>
+    </ClInclude>
+    <ClInclude Include="utils\zstdutils.h">
+      <Filter>utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/RePak.vcxproj.filters
+++ b/src/RePak.vcxproj.filters
@@ -240,6 +240,9 @@
     <ClCompile Include="utils\zstdutils.cpp">
       <Filter>utils</Filter>
     </ClCompile>
+    <ClCompile Include="assets\material_for_aspect.cpp">
+      <Filter>assets</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="assets\assets.h">
@@ -589,6 +592,9 @@
     </ClInclude>
     <ClInclude Include="utils\zstdutils.h">
       <Filter>utils</Filter>
+    </ClInclude>
+    <ClInclude Include="public\material_for_aspect.h">
+      <Filter>public</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -14,6 +14,7 @@
 #define ARIG_VERSION 4
 #define ASEQ_VERSION 7
 #define MATL_VERSION 15
+#define MT4A_VERSION 3
 
 namespace Assets
 {
@@ -26,6 +27,8 @@ namespace Assets
 
 	void AddMaterialAsset_v12(CPakFileBuilder* const pak, const PakGuid_t assetGuid, const char* const assetPath, const rapidjson::Value& mapEntry);
 	void AddMaterialAsset_v15(CPakFileBuilder* const pak, const PakGuid_t assetGuid, const char* const assetPath, const rapidjson::Value& mapEntry);
+
+	void AddMaterialForAspectAsset_v3(CPakFileBuilder* const pak, const PakGuid_t assetGuid, const char* const assetPath, const rapidjson::Value& mapEntry);
 
 	void AddUIImageAsset_v10(CPakFileBuilder* const pak, const PakGuid_t assetGuid, const char* const assetPath, const rapidjson::Value& mapEntry);
 

--- a/src/assets/material.cpp
+++ b/src/assets/material.cpp
@@ -83,13 +83,13 @@ static void Material_AddTextureRefs(CPakFileBuilder* const pak, PakPageLump_s& d
         const size_t strlen = it->name.GetStringLength();
 
         if (end != &start[strlen])
-            Error("Unable to determine bind point for texture #%zu.\n", bindPoint);
+            Error("Unable to determine bind point for texture #%zu.\n", curIndex);
 
         bool success;
         const PakGuid_t textureGuid = Pak_ParseGuid(val, &success);
 
         if (!success)
-            Error("Unable to parse texture #%zu.\n", bindPoint);
+            Error("Unable to parse texture #%zu (bind point #%zu).\n", curIndex, bindPoint);
 
         reinterpret_cast<PakGuid_t*>(dataBuf)[bindPoint] = textureGuid;
         const size_t offset = alignedPathSize + (bindPoint * sizeof(PakGuid_t));
@@ -97,7 +97,7 @@ static void Material_AddTextureRefs(CPakFileBuilder* const pak, PakPageLump_s& d
         Pak_RegisterGuidRefAtOffset(textureGuid, offset, dataChunk, asset);
 
         if (!pak->GetAssetByGuid(textureGuid))
-            Warning("Unable to find texture #%zu within the local assets.\n", bindPoint);
+            Warning("Texture #%zu (bind point #%zu) not found on disk; treating as external reference.\n", curIndex, bindPoint);
     }
 }
 

--- a/src/assets/material_for_aspect.cpp
+++ b/src/assets/material_for_aspect.cpp
@@ -1,0 +1,59 @@
+#include "pch.h"
+#include "assets.h"
+#include "public/material_for_aspect.h"
+
+static void Material4Aspect_InternalAdd(CPakFileBuilder* const pak, const PakGuid_t assetGuid, const char* const assetPath)
+{
+	const std::string mt4aPath = Utils::ChangeExtension(pak->GetAssetPath() + assetPath, "json");
+	rapidjson::Document document;
+
+	if (!JSON_ParseFromFile(mt4aPath.c_str(), "material for aspect", document, false))
+		Error("Failed to open material_for_aspect asset \"%s\".\n", mt4aPath.c_str());
+
+	// Parse manually added entries here.
+	rapidjson::Value::ConstMemberIterator materialsIt;
+	JSON_GetRequired(document, "materials", JSONFieldType_e::kArray, materialsIt);
+
+	const rapidjson::Value::ConstArray materialArray = materialsIt->value.GetArray();
+	const size_t arraySize = materialArray.Size();
+
+	if (arraySize == 0)
+		Error("Array \"materials\" is empty.\n");
+
+	if (arraySize > MaterialShaderType_e::_TYPE_COUNT)
+		Error("Array \"materials\" is too large (%zu > %zu).\n", arraySize, (size_t)MaterialShaderType_e::_TYPE_COUNT);
+
+	PakAsset_t& asset = pak->BeginAsset(assetGuid, assetPath);
+	PakPageLump_s hdrLump = pak->CreatePageLump(sizeof(MaterialForAspect_s), SF_HEAD | SF_CLIENT, 8);
+
+	MaterialForAspect_s* const mt4a = reinterpret_cast<MaterialForAspect_s*>(hdrLump.data);
+
+	int matIndex = -1;
+	for (const auto& material : materialArray)
+	{
+		matIndex++;
+
+		char buffer[32]; const char* base = "material #";
+		char* current = std::copy(base, base + 10, buffer);
+		std::to_chars_result result = std::to_chars(current, buffer + sizeof(buffer), matIndex);
+
+		*result.ptr = '\0';
+
+		const char* dependencyName = nullptr;
+		const PakGuid_t guid = Pak_ParseGuidFromObject(material, buffer, dependencyName);
+
+		mt4a->materials[matIndex] = guid;
+		Pak_RegisterGuidRefAtOffset(guid, offsetof(MaterialForAspect_s, materials) + matIndex * sizeof(PakGuid_t), hdrLump, asset);
+	}
+
+	asset.InitAsset(hdrLump.GetPointer(), sizeof(MaterialForAspect_s), PagePtr_t::NullPtr(), MT4A_VERSION, AssetType::MT4A);
+	asset.SetHeaderPointer(hdrLump.data);
+
+	pak->FinishAsset();
+}
+
+void Assets::AddMaterialForAspectAsset_v3(CPakFileBuilder* const pak, const PakGuid_t assetGuid, const char* const assetPath, const rapidjson::Value& mapEntry)
+{
+	UNUSED(mapEntry);
+	Material4Aspect_InternalAdd(pak, assetGuid, assetPath);
+};

--- a/src/logic/pakfile.cpp
+++ b/src/logic/pakfile.cpp
@@ -99,7 +99,9 @@ void CPakFileBuilder::AddAsset(const rapidjson::Value& file)
 	HANDLE_ASSET_TYPE("txtr", assetType, assetPath, AssetScope_e::kClientOnly, file, Assets::AddTextureAsset_v8, Assets::AddTextureAsset_v8);
 	HANDLE_ASSET_TYPE("txan", assetType, assetPath, AssetScope_e::kClientOnly, file, nullptr, Assets::AddTextureAnimAsset_v1);
 	HANDLE_ASSET_TYPE("uimg", assetType, assetPath, AssetScope_e::kClientOnly, file, Assets::AddUIImageAsset_v10, Assets::AddUIImageAsset_v10);
+
 	HANDLE_ASSET_TYPE("matl", assetType, assetPath, AssetScope_e::kClientOnly, file, Assets::AddMaterialAsset_v12, Assets::AddMaterialAsset_v15);
+	HANDLE_ASSET_TYPE("mt4a", assetType, assetPath, AssetScope_e::kClientOnly, file, nullptr, Assets::AddMaterialForAspectAsset_v3);
 
 	HANDLE_ASSET_TYPE("shdr", assetType, assetPath, AssetScope_e::kClientOnly, file, Assets::AddShaderAsset_v8, Assets::AddShaderAsset_v12);
 	HANDLE_ASSET_TYPE("shds", assetType, assetPath, AssetScope_e::kClientOnly, file, Assets::AddShaderSetAsset_v8, Assets::AddShaderSetAsset_v11);

--- a/src/logic/pakfile.cpp
+++ b/src/logic/pakfile.cpp
@@ -539,7 +539,7 @@ static bool Pak_StreamToStreamEncode(BinaryIO& inStream, BinaryIO& outStream, co
 
 			if (ZSTD_isError(remaining))
 			{
-				Warning("Failed to compress frame at %zd to frame at %zd: [%s].\n",
+				Warning("Failed to compress stream at %zd to stream at %zd: [%s].\n",
 					inStream.TellGet(), outStream.TellPut(), ZSTD_getErrorName(remaining));
 
 				return false;

--- a/src/logic/pakfile.cpp
+++ b/src/logic/pakfile.cpp
@@ -177,6 +177,21 @@ int64_t CPakFileBuilder::AddStreamingFileReference(const char* const path, const
 //-----------------------------------------------------------------------------
 PakStreamSetEntry_s CPakFileBuilder::AddStreamingDataEntry(const int64_t size, const uint8_t* const data, const PakStreamSet_e set)
 {
+	const size_t pageAligned = IALIGN(size, STARPAK_DATABLOCK_ALIGNMENT);
+	const size_t windowRemainder = pageAligned - size;
+
+	if (windowRemainder > 0)
+	{
+		// Code bug, data must always be provided with size aligned to
+		// STARPAK_DATABLOCK_ALIGNMENT as otherwise the de-duplication
+		// code will not work. starpak data is always page aligned. We
+		// will still continue to store the data as it will get padded
+		// out in the stream file builder within the file itself.
+		Warning("%s: didn't receive enough window for page alignment! [%zu < %zu].\n",
+			__FUNCTION__, size, pageAligned);
+		assert(0);
+	}
+
 	StreamAddEntryResults_s results;
 	m_streamBuilder->AddStreamingDataEntry(size, data, set, results);
 

--- a/src/logic/pakfile.cpp
+++ b/src/logic/pakfile.cpp
@@ -7,9 +7,7 @@
 #include "pch.h"
 #include "pakfile.h"
 #include "assets/assets.h"
-
-#include "thirdparty/zstd/zstd.h"
-#include "thirdparty/zstd/decompress/zstd_decompress_internal.h"
+#include "utils/zstdutils.h"
 
 CPakFileBuilder::CPakFileBuilder(const CBuildSettings* const buildSettings, CStreamFileBuilder* const streamBuilder)
 {
@@ -454,24 +452,14 @@ static inline size_t Pak_GetHeaderSize(const uint16_t version)
 // note(amos): unlike the pak file header, the zstd frame header needs to know
 // the uncompressed size without the file header.
 //-----------------------------------------------------------------------------
-static ZSTD_CCtx* Pak_InitEncoderContext(const size_t uncompressedBlockSize, const int compressLevel, const int workerCount)
+static bool Pak_InitEncoderContext(ZSTD_CCtx* const cctx, const size_t uncompressedBlockSize, const int compressLevel, const int workerCount)
 {
-	ZSTD_CCtx* const cctx = ZSTD_createCCtx();
-
-	if (!cctx)
-	{
-		Warning("Failed to create encoder context.\n");
-		return nullptr;
-	}
-
 	size_t result = ZSTD_CCtx_setPledgedSrcSize(cctx, uncompressedBlockSize);
 
 	if (ZSTD_isError(result))
 	{
 		Warning("Failed to set pledged source size %zu: [%s].\n", uncompressedBlockSize, ZSTD_getErrorName(result));
-		ZSTD_freeCCtx(cctx);
-
-		return nullptr;
+		return false;
 	}
 
 	result = ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, compressLevel);
@@ -479,9 +467,7 @@ static ZSTD_CCtx* Pak_InitEncoderContext(const size_t uncompressedBlockSize, con
 	if (ZSTD_isError(result))
 	{
 		Warning("Failed to set compression level %i: [%s].\n", compressLevel, ZSTD_getErrorName(result));
-		ZSTD_freeCCtx(cctx);
-
-		return nullptr;
+		return false;
 	}
 
 	result = ZSTD_CCtx_setParameter(cctx, ZSTD_c_nbWorkers, workerCount);
@@ -489,12 +475,10 @@ static ZSTD_CCtx* Pak_InitEncoderContext(const size_t uncompressedBlockSize, con
 	if (ZSTD_isError(result))
 	{
 		Warning("Failed to set worker count %i: [%s].\n", workerCount, ZSTD_getErrorName(result));
-		ZSTD_freeCCtx(cctx);
-
-		return nullptr;
+		return false;
 	}
 
-	return cctx;
+	return true;
 }
 
 //-----------------------------------------------------------------------------
@@ -504,10 +488,9 @@ static bool Pak_StreamToStreamEncode(BinaryIO& inStream, BinaryIO& outStream, co
 {
 	// only the data past the main header gets compressed.
 	const size_t decodedFrameSize = (static_cast<size_t>(inStream.GetSize()) - headerSize);
+	ZSTDEncoder_s encoder;
 
-	ZSTD_CCtx* const cctx = Pak_InitEncoderContext(decodedFrameSize, compressLevel, workerCount);
-
-	if (!cctx)
+	if (!Pak_InitEncoderContext(&encoder.cctx, decodedFrameSize, compressLevel, workerCount))
 	{
 		return false;
 	}
@@ -518,8 +501,6 @@ static bool Pak_StreamToStreamEncode(BinaryIO& inStream, BinaryIO& outStream, co
 	if (!buffInPtr)
 	{
 		Warning("Failed to allocate input stream buffer of size %zu.\n", buffInSize);
-		ZSTD_freeCCtx(cctx);
-
 		return false;
 	}
 
@@ -529,8 +510,6 @@ static bool Pak_StreamToStreamEncode(BinaryIO& inStream, BinaryIO& outStream, co
 	if (!buffOutPtr)
 	{
 		Warning("Failed to allocate output stream buffer of size %zu.\n", buffOutSize);
-		ZSTD_freeCCtx(cctx);
-
 		return false;
 	}
 
@@ -556,14 +535,13 @@ static bool Pak_StreamToStreamEncode(BinaryIO& inStream, BinaryIO& outStream, co
 		bool finished;
 		do {
 			ZSTD_outBuffer outputFrame = { buffOut, buffOutSize, 0 };
-			size_t const remaining = ZSTD_compressStream2(cctx, &outputFrame, &inputFrame, mode);
+			size_t const remaining = ZSTD_compressStream2(&encoder.cctx, &outputFrame, &inputFrame, mode);
 
 			if (ZSTD_isError(remaining))
 			{
 				Warning("Failed to compress frame at %zd to frame at %zd: [%s].\n",
 					inStream.TellGet(), outStream.TellPut(), ZSTD_getErrorName(remaining));
 
-				ZSTD_freeCCtx(cctx);
 				return false;
 			}
 
@@ -573,7 +551,6 @@ static bool Pak_StreamToStreamEncode(BinaryIO& inStream, BinaryIO& outStream, co
 		} while (!finished);
 	}
 
-	ZSTD_freeCCtx(cctx);
 	return true;
 }
 

--- a/src/public/material_for_aspect.h
+++ b/src/public/material_for_aspect.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "material.h"
+
+struct MaterialForAspect_s
+{
+	// Each shader type has a material, but they can be 0 for some.
+	// It depends on the mt4a asset and what types it supports.
+	PakGuid_t materials[MaterialShaderType_e::_TYPE_COUNT];
+};

--- a/src/public/rpak.h
+++ b/src/public/rpak.h
@@ -31,6 +31,7 @@
 #define TYPE_STLT	MAKE_FOURCC('s', 't', 'l', 't') // stlt
 #define TYPE_STGS	MAKE_FOURCC('s', 't', 'g', 's') // stgs
 #define TYPE_MATL	MAKE_FOURCC('m', 'a', 't', 'l') // matl
+#define TYPE_MT4A	MAKE_FOURCC('m', 't', '4', 'a') // mt4a
 #define TYPE_ASEQ	MAKE_FOURCC('a', 's', 'e', 'q') // aseq
 #define TYPE_ARIG	MAKE_FOURCC('a', 'r', 'i', 'g') // arig
 #define TYPE_SHDS	MAKE_FOURCC('s', 'h', 'd', 's') // shds
@@ -50,6 +51,7 @@ enum class AssetType : uint32_t
 	STLT = TYPE_STLT, // settings layout
 	STGS = TYPE_STGS, // settings
 	MATL = TYPE_MATL, // material
+	MT4A = TYPE_MT4A, // material for aspect
 	ASEQ = TYPE_ASEQ, // animation sequence
 	ARIG = TYPE_ARIG, // animation rig
 	SHDS = TYPE_SHDS, // shaderset

--- a/src/thirdparty/zstd/zstd.h
+++ b/src/thirdparty/zstd/zstd.h
@@ -280,6 +280,7 @@ ZSTDLIB_API int          ZSTD_defaultCLevel(void);         /*!< default compress
 typedef struct ZSTD_CCtx_s ZSTD_CCtx;
 ZSTDLIB_API ZSTD_CCtx* ZSTD_createCCtx(void);
 ZSTDLIB_API size_t     ZSTD_freeCCtx(ZSTD_CCtx* cctx);  /* compatible with NULL pointer */
+ZSTDLIB_API void       ZSTD_freeCCtxContent(ZSTD_CCtx* cctx);
 
 /*! ZSTD_compressCCtx() :
  *  Same as ZSTD_compress(), using an explicit ZSTD_CCtx.
@@ -303,6 +304,7 @@ ZSTDLIB_API size_t ZSTD_compressCCtx(ZSTD_CCtx* cctx,
 typedef struct ZSTD_DCtx_s ZSTD_DCtx;
 ZSTDLIB_API ZSTD_DCtx* ZSTD_createDCtx(void);
 ZSTDLIB_API size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);  /* accept NULL pointer */
+ZSTDLIB_API void       ZSTD_freeDCtxContent(ZSTD_DCtx* dctx);
 
 /*! ZSTD_decompressDCtx() :
  *  Same as ZSTD_decompress(),
@@ -1818,6 +1820,9 @@ ZSTDLIB_STATIC_API size_t ZSTD_estimateDStreamSize_fromFrame(const void* src, si
 ZSTDLIB_STATIC_API size_t ZSTD_estimateCDictSize(size_t dictSize, int compressionLevel);
 ZSTDLIB_STATIC_API size_t ZSTD_estimateCDictSize_advanced(size_t dictSize, ZSTD_compressionParameters cParams, ZSTD_dictLoadMethod_e dictLoadMethod);
 ZSTDLIB_STATIC_API size_t ZSTD_estimateDDictSize(size_t dictSize, ZSTD_dictLoadMethod_e dictLoadMethod);
+
+ZSTDLIB_STATIC_API void ZSTD_initCCtx(ZSTD_CCtx* cctx);
+ZSTDLIB_STATIC_API void ZSTD_initDCtx(ZSTD_DCtx* dctx);
 
 /*! ZSTD_initStatic*() :
  *  Initialize an object using a pre-allocated fixed-size buffer.

--- a/src/utils/zstdutils.cpp
+++ b/src/utils/zstdutils.cpp
@@ -1,0 +1,24 @@
+#include "pch.h"
+#include "zstdutils.h"
+
+ZSTDEncoder_s::ZSTDEncoder_s()
+{
+	cctx.customMem = ZSTD_defaultCMem;
+	ZSTD_initCCtx(&cctx);
+}
+
+ZSTDEncoder_s::~ZSTDEncoder_s()
+{
+	ZSTD_freeCCtxContent(&cctx);
+}
+
+ZSTDDecoder_s::ZSTDDecoder_s()
+{
+	dctx.customMem = ZSTD_defaultCMem;
+	ZSTD_initDCtx(&dctx);
+}
+
+ZSTDDecoder_s::~ZSTDDecoder_s()
+{
+	ZSTD_freeDCtxContent(&dctx);
+}

--- a/src/utils/zstdutils.h
+++ b/src/utils/zstdutils.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "thirdparty/zstd/zstd.h"
+#include "thirdparty/zstd/compress/zstd_compress_internal.h"
+#include "thirdparty/zstd/decompress/zstd_decompress_internal.h"
+
+struct ZSTDEncoder_s
+{
+	ZSTDEncoder_s();
+	~ZSTDEncoder_s();
+
+	ZSTD_CCtx cctx;
+};
+
+struct ZSTDDecoder_s
+{
+	ZSTDDecoder_s();
+	~ZSTDDecoder_s();
+
+	ZSTD_DCtx dctx;
+};


### PR DESCRIPTION
Starpak data is always page aligned, and the table at the end of the file which we use to hash existing data also has a size aligned to `STARPAK_DATABLOCK_ALIGNMENT`. However, the data buffer we feed to `CPakFileBuilder::AddStreamingDataEntry` wasn't aligned to `STARPAK_DATABLOCK_ALIGNMENT`, so the hash result will always differ to that of the original data even if the data itself was identical, causing the data to be not deduplicated.

Added logic to page align the buffer so the hashing algorithm can hash the window remainder as well.
Also added a warning and an assert to catch future regressions may this system ever be modified.

This fixes the cases where some texture data, and virtually all model vertex groups weren't deduplicated.
