### PR TITLE
[RePak] Minor R2 Fixes

### DIFF
--- a/src/public/texture.h
+++ b/src/public/texture.h
@@ -2,7 +2,7 @@
 
 #define MAX_MIPS_PER_TEXTURE 13 // max total mips per texture
 
-#define MAX_PERM_MIP_SIZE	0x3FFF // "Any MIP below 64kiB is permanent."
+#define MAX_PERM_MIP_SIZE	0xFFFF // "Any MIP below 64kiB is permanent."
 #define MAX_STREAM_MIP_SIZE	0xFFFFF
 
 #define TEXTURE_INVALID_FORMAT_INDEX 0xFFFF


### PR DESCRIPTION
- Fix colpass materials in matl V12
- Fix blendstates in matl V12
- Fix MAX_PERM_MIP_SIZE. the only solid number we have for this is 64kib, R5 does not follow this rule (likely uses algorithm) and users packing for R5 have texture metadata.