### PR TITLE
Minor fixes

### DIFF
--- a/src/assets/material.cpp
+++ b/src/assets/material.cpp
@@ -514,31 +514,6 @@ static void Material_InternalAddMaterialV12(CPakFileBuilder* const pak, const Pa
     if (matlAsset.materialType != _TYPE_LEGACY)
         Error("Material type '%s' is not supported on version 12 (Titanfall 2) assets.\n", matlAsset.materialTypeStr.c_str());
 
-    if ((matlAsset.materialTypeStr == "fix" || matlAsset.materialTypeStr == "skn"))
-    {
-        for (int i = 0; i < 2; ++i)
-        {
-            MaterialDXState_v15_t& dxState = matlAsset.dxStates[i];
-
-            dxState.blendStates[0] = MaterialBlendState_t(false, false, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
-            dxState.blendStates[1] = MaterialBlendState_t(false, false, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
-            dxState.blendStates[2] = MaterialBlendState_t(false, false, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
-            dxState.blendStates[3] = MaterialBlendState_t(false, false, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0x0);
-        }
-    }
-    else
-    {
-        for (int i = 0; i < 2; ++i)
-        {
-            MaterialDXState_v15_t& dxState = matlAsset.dxStates[i];
-
-            dxState.blendStates[0] = MaterialBlendState_t(false, true, D3D11_BLEND_ONE, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
-            dxState.blendStates[1] = MaterialBlendState_t(false, true, D3D11_BLEND_ONE, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0xF);
-            dxState.blendStates[2] = MaterialBlendState_t(false, true, D3D11_BLEND_ONE, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_OP_ADD, D3D11_BLEND_ONE, D3D11_BLEND_ZERO, D3D11_BLEND_OP_ADD, 0xF);
-            dxState.blendStates[3] = MaterialBlendState_t(false, true, D3D11_BLEND_ONE, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_OP_ADD, D3D11_BLEND_INV_DEST_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD, 0x0);
-        }
-    }
-
     const size_t surfaceProp1Size = !matlAsset.surface.empty() ? (matlAsset.surface.length() + 1) : 0;
     const size_t surfaceProp2Size = !matlAsset.surface2.empty() ? (matlAsset.surface2.length() + 1) : 0;
 

--- a/src/assets/settings.cpp
+++ b/src/assets/settings.cpp
@@ -292,12 +292,12 @@ static void SettingsAsset_CalculateModValuesBuffers(const rapidjson::Value& modV
 
         switch (item.modType)
         {
-        case SettingsModType_e::kIntPlus:
+        case SettingsModType_e::kIntAdd:
         case SettingsModType_e::kIntMultiply:
             valueTypeRequested = JSONFieldType_e::kSint32;
             fieldTypeRequested = SettingsFieldType_e::ST_Int;
             break;
-        case SettingsModType_e::kFloatPlus:
+        case SettingsModType_e::kFloatAdd:
         case SettingsModType_e::kFloatMultiply:
             valueTypeRequested = JSONFieldType_e::kFloat;
             fieldTypeRequested = SettingsFieldType_e::ST_Float;
@@ -586,11 +586,11 @@ static void SettingsAsset_WriteModValues(const SettingsModCache_s& modCache, con
 
         switch (item.modType)
         {
-        case SettingsModType_e::kIntPlus:
+        case SettingsModType_e::kIntAdd:
         case SettingsModType_e::kIntMultiply:
             mod->value.intValue = item.valueIt->value.GetInt();
             break;
-        case SettingsModType_e::kFloatPlus:
+        case SettingsModType_e::kFloatAdd:
         case SettingsModType_e::kFloatMultiply:
             mod->value.floatValue = item.valueIt->value.GetFloat();
             break;

--- a/src/public/settings.h
+++ b/src/public/settings.h
@@ -3,9 +3,9 @@
 
 enum SettingsModType_e : unsigned short
 {
-	kIntPlus = 0x0,
+	kIntAdd = 0x0,
 	kIntMultiply = 0x1,
-	kFloatPlus = 0x2,
+	kFloatAdd = 0x2,
 	kFloatMultiply = 0x3,
 	kBool = 0x4,
 	kNumber = 0x5,
@@ -16,9 +16,9 @@ enum SettingsModType_e : unsigned short
 
 inline const char* const g_settingsModType[SETTINGS_MOD_COUNT] =
 {
-	"int_plus",
+	"int_add",
 	"int_multipy",
-	"float_plus",
+	"float_add",
 	"float_multipy",
 	"bool",
 	"number",

--- a/src/public/texture.h
+++ b/src/public/texture.h
@@ -2,7 +2,7 @@
 
 #define MAX_MIPS_PER_TEXTURE 13 // max total mips per texture
 
-#define MAX_PERM_MIP_SIZE	0x3FFF // "Any MIP below 64kiB is permanent."
+#define MAX_PERM_MIP_SIZE	0xFFFF // "Any MIP below 64kiB is permanent."
 #define MAX_STREAM_MIP_SIZE	0xFFFFF
 
 #define TEXTURE_INVALID_FORMAT_INDEX 0xFFFF


### PR DESCRIPTION
- The value of the constant `MAX_PERM_MIP_SIZE` was incorrect (16K), it has now been corrected (64K).
- Fixed a typo in `g_settingsModType` and `SettingsModType_e` that could cause confusion for anyone working with this code
- Optimized Utils::VFormat() by storing the results in just 1 container instead of copying it over from a temp, and to only run the copy logic if the initial encoding pass was succesful.