### PR TITLE
Minor fixes

### DIFF
--- a/src/application/repak.cpp
+++ b/src/application/repak.cpp
@@ -34,6 +34,7 @@ static void RePak_Shutdown(CBuildSettings& settings, CStreamFileBuilder& streamB
 
 static void RePak_ParseListedDocument(js::Document& doc, const char* const docPath, const char* const docName)
 {
+    Log("Parsing listed build map \"%s\".\n", docName);
     std::string finalName = docName;
 
     Utils::ResolvePath(finalName, docPath);

--- a/src/logic/pakfile.cpp
+++ b/src/logic/pakfile.cpp
@@ -76,7 +76,12 @@ bool CPakFileBuilder::AddJSONAsset(const char* const targetType, const char* con
 	return true;
 }
 
-#define HANDLE_ASSET_TYPE(targetType, assetType, assetPath, assetScope, asset, func_r2, func_r5) if (AddJSONAsset(targetType, assetType, assetPath, assetScope, asset, func_r2, func_r5)) return;
+#define HANDLE_ASSET_TYPE(targetType, assetType, assetPath, assetScope, asset, func_r2, func_r5) \
+		if (AddJSONAsset(targetType, assetType, assetPath, assetScope, asset, func_r2, func_r5)) \
+			{ \
+				g_currentAsset = nullptr; \
+				return; \
+			}
 
 //-----------------------------------------------------------------------------
 // purpose: installs asset types and their callbacks

--- a/src/thirdparty/rapidcsv/rapidcsv.h
+++ b/src/thirdparty/rapidcsv/rapidcsv.h
@@ -2,7 +2,7 @@
  * rapidcsv.h
  *
  * URL:      https://github.com/d99kris/rapidcsv
- * Version:  8.85
+ * Version:  8.87
  *
  * Copyright (C) 2017-2025 Kristofer Berggren
  * All rights reserved.
@@ -304,7 +304,7 @@ namespace rapidcsv
   }
 
   template<typename T>
-  using ConvFunc = std::function<void (const std::string & pStr, T & pVal)>;
+  using ConvFunc = std::function<void (const std::string& pStr, T& pVal)>;
 
   /**
    * @brief     Datastructure holding parameters controlling which row and column should be
@@ -774,7 +774,18 @@ namespace rapidcsv
       {
         if (std::distance(mData.begin(), itRow) >= mLabelParams.mColumnNameIdx)
         {
-          itRow->erase(itRow->begin() + static_cast<int>(dataColumnIdx));
+          if (dataColumnIdx < itRow->size())
+          {
+            itRow->erase(itRow->begin() + static_cast<int>(dataColumnIdx));
+          }
+          else
+          {
+            const std::string errStr = "column out of range: " +
+              std::to_string(pColumnIdx) + " (on row " +
+              std::to_string(std::distance(mData.begin(), itRow)) +
+              ")";
+            throw std::out_of_range(errStr);
+          }
         }
       }
 
@@ -841,7 +852,18 @@ namespace rapidcsv
         if (std::distance(mData.begin(), itRow) >= mLabelParams.mColumnNameIdx)
         {
           const size_t rowIdx = static_cast<size_t>(std::distance(mData.begin(), itRow));
-          itRow->insert(itRow->begin() + static_cast<int>(dataColumnIdx), column.at(rowIdx));
+          if (dataColumnIdx <= itRow->size())
+          {
+            itRow->insert(itRow->begin() + static_cast<int>(dataColumnIdx), column.at(rowIdx));
+          }
+          else
+          {
+            const std::string errStr = "column out of range: " +
+              std::to_string(pColumnIdx) + " (on row " +
+              std::to_string(std::distance(mData.begin(), itRow)) +
+              ")";
+            throw std::out_of_range(errStr);
+          }
         }
       }
 
@@ -1793,19 +1815,22 @@ namespace rapidcsv
 
     size_t GetDataColumnCount() const
     {
-      const size_t firstDataRow = static_cast<size_t>((mLabelParams.mColumnNameIdx >= 0) ? mLabelParams.mColumnNameIdx : 0);
+      const size_t firstDataRow =
+        static_cast<size_t>((mLabelParams.mColumnNameIdx >= 0) ? mLabelParams.mColumnNameIdx : 0);
       return (mData.size() > firstDataRow) ? mData.at(firstDataRow).size() : 0;
     }
 
     inline size_t GetDataRowIndex(const size_t pRowIdx) const
     {
-      const size_t firstDataRow = static_cast<size_t>((mLabelParams.mColumnNameIdx + 1 >= 0) ? mLabelParams.mColumnNameIdx + 1 : 0);
+      const size_t firstDataRow =
+        static_cast<size_t>((mLabelParams.mColumnNameIdx + 1 >= 0) ? mLabelParams.mColumnNameIdx + 1 : 0);
       return pRowIdx + firstDataRow;
     }
 
     inline size_t GetDataColumnIndex(const size_t pColumnIdx) const
     {
-      const size_t firstDataColumn = static_cast<size_t>((mLabelParams.mRowNameIdx + 1 >= 0) ? mLabelParams.mRowNameIdx + 1 : 0);
+      const size_t firstDataColumn =
+        static_cast<size_t>((mLabelParams.mRowNameIdx + 1 >= 0) ? mLabelParams.mRowNameIdx + 1 : 0);
       return pColumnIdx + firstDataColumn;
     }
 


### PR DESCRIPTION
- Fixes the issue where `g_currentAsset` wouldn't be nulled if an asset was packaged, causing confusion on Warning and Error calls outside the asset handling code.
- Fixes the issue where if a build map inside a build list failed to parse, the user wouldn't be notified which build map in the list is causing the error.
- Upgrades RapidCSV to 8.87.