### PR TITLE
Append slash bug fix and LoadLibrary support

### DIFF
--- a/src/logic/buildsettings.cpp
+++ b/src/logic/buildsettings.cpp
@@ -25,6 +25,8 @@ void CBuildSettings::Init(const js::Document& doc, const char* const buildMapFil
 
 	// Determine final build path from map file.
 	m_outputPath = JSON_GetValueRequired<const char*>(doc, "outputDir");
+
+	Utils::AppendSlash(m_outputPath);
 	Utils::ResolvePath(m_outputPath, m_buildMapPath);
 
 	// Create output directory if it does not exist yet.

--- a/src/logic/pakfile.cpp
+++ b/src/logic/pakfile.cpp
@@ -721,6 +721,13 @@ void CPakFileBuilder::BuildFromMap(const js::Document& doc)
 	const size_t decompressedFileSize = out.GetSize();
 	size_t compressedFileSize = 0;
 
+	// If this is set and we have "example.rpak", the runtime will load the
+	// library `example.dll` during the load of `example.rpak`, from the same
+	// directory the pak is being loaded from. The loading of the library
+	// happens before the individual assets are being loaded and parsed.
+	if (JSON_GetValueOrDefault(doc, "hasDynamicLibrary", false))
+		m_Header.flags |= PAK_HEADER_FLAGS_HAS_MODULE;
+
 	const int compressLevel = JSON_GetValueOrDefault(doc, "compressLevel", 0);
 
 	if (compressLevel > 0 && decompressedFileSize > Pak_GetHeaderSize(m_Header.fileVersion))

--- a/src/logic/pakfile.cpp
+++ b/src/logic/pakfile.cpp
@@ -639,6 +639,8 @@ void CPakFileBuilder::BuildFromMap(const js::Document& doc)
 {
 	// determine source asset directory from map file
 	m_assetPath = JSON_GetValueRequired<const char*>(doc, "assetsDir");
+
+	Utils::AppendSlash(m_assetPath);
 	Utils::ResolvePath(m_assetPath, m_buildSettings->GetBuildMapPath());
 
 	this->SetVersion(static_cast<uint16_t>(m_buildSettings->GetPakVersion()));

--- a/src/public/rpak.h
+++ b/src/public/rpak.h
@@ -12,6 +12,7 @@
 #define RPAK_MAGIC (('k'<<24)+('a'<<16)+('P'<<8)+'R')
 #define RPAK_EXTENSION ".rpak"
 
+#define PAK_HEADER_FLAGS_HAS_MODULE    (1<<0) // instructs the runtime to load the library corresponding to this RPak.
 #define PAK_HEADER_FLAGS_RTECH_ENCODED (1<<8) // use the RTech decoder in the runtime.
 #define PAK_HEADER_FLAGS_ZSTD_ENCODED  (1<<9) // use the ZStd decoder in the runtime.
 


### PR DESCRIPTION
- Fixes #56 (was fixed a few days ago but never tested and pushed).
- Adds option `hasDynamicLibrary` which determines whether an RPak has a corresponding library file that should be loaded (ui.rpak and ui.dll for example).