### PR TITLE
Stream cache bug fix and streaming file improvements

### DIFF
--- a/src/logic/pakfile.cpp
+++ b/src/logic/pakfile.cpp
@@ -174,7 +174,7 @@ int64_t CPakFileBuilder::AddStreamingFileReference(const char* const path, const
 			streamSetName, path, PAK_MAX_STREAMING_FILE_HANDLES_PER_SET, newSize);
 	}
 
-	vec.push_back(path);
+	vec.emplace_back(path);
 	return count;
 }
 

--- a/src/logic/pakfile.cpp
+++ b/src/logic/pakfile.cpp
@@ -203,7 +203,7 @@ PakStreamSetEntry_s CPakFileBuilder::AddStreamingDataEntry(const int64_t size, c
 
 	PakStreamSetEntry_s block;
 
-	block.streamOffset = results.offset;
+	block.streamOffset = results.dataOffset;
 	block.streamIndex = AddStreamingFileReference(results.streamFile, set == STREAMING_SET_MANDATORY);
 
 	return block;

--- a/src/logic/streamcache.cpp
+++ b/src/logic/streamcache.cpp
@@ -329,6 +329,9 @@ bool CStreamCache::Find(const StreamCacheFindParams_s& params, StreamCacheFindRe
 		if (!SIMD_CompareM128i(entry.hash, params.hash))
 			continue;
 
+		if (!IsStreamFileInFilter(file.streamFilePath))
+			continue; // note(amos): don't return here, as this data can also exist in other stream files that are in the filter!
+
 		result.fileEntry = &file;
 		result.dataEntry = &entry;
 
@@ -395,4 +398,17 @@ void CStreamCache::Save(BinaryIO& io)
 	{
 		io.Write(dataEntry);
 	}
+}
+
+void CStreamCache::AddStreamFileToFilter(const char* const streamFile, const size_t nameLen)
+{
+	m_cacheFilter.insert({ streamFile, nameLen });
+}
+
+bool CStreamCache::IsStreamFileInFilter(const std::string& streamFile) const
+{
+	if (m_cacheFilter.empty())
+		return true; // No filter provided, all streaming files inside the cache will be eligible for use.
+
+	return m_cacheFilter.find(streamFile) != m_cacheFilter.end();
 }

--- a/src/logic/streamcache.cpp
+++ b/src/logic/streamcache.cpp
@@ -153,7 +153,7 @@ void CStreamCache::BuildMapFromGamePaks(const char* const streamCacheFile)
 			// ideally we don't have entries over 2gb.
 			assert(entryHeader->size < INT32_MAX);
 
-			MurmurHash3_x64_128(entryData, static_cast<int>(entryHeader->size), MURMUR_SEED, &cacheEntry.hash);
+			MurmurHash3_x64_128(entryData, static_cast<size_t>(entryHeader->size), MURMUR_SEED, &cacheEntry.hash);
 			_aligned_free(entryData);
 		}
 
@@ -301,7 +301,7 @@ StreamCacheFileHeader_s CStreamCache::ConstructHeader() const
 StreamCacheFindParams_s CStreamCache::CreateParams(const uint8_t* const data, const int64_t size, const char* const newStarpak, const bool newIsOptional)
 {
 	__m128i hash;
-	MurmurHash3_x64_128(data, static_cast<int>(size), MURMUR_SEED, &hash);
+	MurmurHash3_x64_128(data, static_cast<size_t>(size), MURMUR_SEED, &hash);
 
 	StreamCacheFindParams_s ret;
 

--- a/src/logic/streamcache.cpp
+++ b/src/logic/streamcache.cpp
@@ -97,7 +97,7 @@ void CStreamCache::BuildMapFromGamePaks(const char* const streamCacheFile)
 
 		if (starpakFileHeader.magic != STARPAK_MAGIC)
 		{
-			Error("Streaming file \"%s\" has an invalid file magic; expected %x, got %x.\n", starpakPath.c_str(), starpakFileHeader.magic, STARPAK_MAGIC);
+			Error("Streaming file \"%s\" has an invalid file magic; expected %x, got %x.\n", starpakPath.c_str(), STARPAK_MAGIC, starpakFileHeader.magic);
 			continue;
 		}
 

--- a/src/logic/streamcache.h
+++ b/src/logic/streamcache.h
@@ -4,7 +4,7 @@
 
 #define STREAM_CACHE_FILE_MAGIC ('S'+('R'<<8)+('M'<<16)+('p'<<24))
 #define STREAM_CACHE_FILE_MAJOR_VERSION 2
-#define STREAM_CACHE_FILE_MINOR_VERSION 3
+#define STREAM_CACHE_FILE_MINOR_VERSION 4
 
 struct StreamCacheFileHeader_s
 {
@@ -62,7 +62,9 @@ public:
 
 	void Save(BinaryIO& io);
 
+	void AddStreamFileToFilter(const std::string& streamFile);
 	void AddStreamFileToFilter(const char* const streamFile, const size_t nameLen);
+
 	bool IsStreamFileInFilter(const std::string& streamFile) const;
 
 	inline bool HasStreamFileFilter() const { return !m_cacheFilter.empty(); }

--- a/src/logic/streamcache.h
+++ b/src/logic/streamcache.h
@@ -21,8 +21,8 @@ struct StreamCacheFileHeader_s
 
 struct StreamCacheFileEntry_s
 {
-	bool optional;
-	std::string path;
+	bool isOptional;
+	std::string streamFilePath;
 };
 
 struct StreamCacheDataEntry_s
@@ -37,8 +37,7 @@ struct StreamCacheFindParams_s
 {
 	__m128i hash;
 	int64_t size;
-	const char* newStarpak;
-	bool newIsOptional;
+	const char* streamFilePath;
 };
 
 struct StreamCacheFindResult_s
@@ -56,10 +55,10 @@ public:
 	int64_t AddStarpakPathToCache(const std::string& path, const bool optional);
 	StreamCacheFileHeader_s ConstructHeader() const;
 
-	static StreamCacheFindParams_s CreateParams(const uint8_t* const data, const int64_t size, const char* const newStarpak, const bool newIsOptional);
+	static StreamCacheFindParams_s CreateParams(const uint8_t* const data, const int64_t size, const char* const streamFilePath);
 
-	bool Find(const StreamCacheFindParams_s& params, StreamCacheFindResult_s& result);
-	void Add(const StreamCacheFindParams_s& params, const int64_t offset);
+	bool Find(const StreamCacheFindParams_s& params, StreamCacheFindResult_s& result, const bool optional);
+	void Add(const StreamCacheFindParams_s& params, const int64_t offset, const bool optional);
 
 	void Save(BinaryIO& io);
 

--- a/src/logic/streamcache.h
+++ b/src/logic/streamcache.h
@@ -4,7 +4,7 @@
 
 #define STREAM_CACHE_FILE_MAGIC ('S'+('R'<<8)+('M'<<16)+('p'<<24))
 #define STREAM_CACHE_FILE_MAJOR_VERSION 2
-#define STREAM_CACHE_FILE_MINOR_VERSION 1
+#define STREAM_CACHE_FILE_MINOR_VERSION 3
 
 struct StreamCacheFileHeader_s
 {
@@ -66,6 +66,4 @@ public:
 private:
 	std::vector<StreamCacheFileEntry_s> m_streamFiles;
 	std::vector<StreamCacheDataEntry_s> m_dataEntries;
-
-	size_t m_starpakBufSize;
 };

--- a/src/logic/streamcache.h
+++ b/src/logic/streamcache.h
@@ -62,7 +62,13 @@ public:
 
 	void Save(BinaryIO& io);
 
+	void AddStreamFileToFilter(const char* const streamFile, const size_t nameLen);
+	bool IsStreamFileInFilter(const std::string& streamFile) const;
+
+	inline bool HasStreamFileFilter() const { return !m_cacheFilter.empty(); }
+
 private:
 	std::vector<StreamCacheFileEntry_s> m_streamFiles;
 	std::vector<StreamCacheDataEntry_s> m_dataEntries;
+	std::unordered_set<std::string> m_cacheFilter;
 };

--- a/src/logic/streamfile.cpp
+++ b/src/logic/streamfile.cpp
@@ -147,6 +147,7 @@ bool CStreamFileBuilder::AddStreamingDataEntry(const int64_t size, const uint8_t
 	if (m_streamCache.Find(params, result, !isMandatory))
 	{
 		outResults.streamFile = result.fileEntry->streamFilePath.c_str();
+		outResults.pathIndex = result.dataEntry->pathIndex;
 		outResults.dataOffset = result.dataEntry->dataOffset;
 
 		return false; // Data wasn't added, but mapped to existing data.

--- a/src/logic/streamfile.h
+++ b/src/logic/streamfile.h
@@ -19,7 +19,7 @@ public:
 	void Init(const js::Document& doc, const bool useOptional);
 	void Shutdown();
 
-	void CreateStreamFileStream(const char* const path, const PakStreamSet_e set);
+	void CreateStreamFileStream(const std::string& streamFilePath, const PakStreamSet_e set);
 	void FinishStreamFileStream(const PakStreamSet_e set);
 
 	bool AddStreamingDataEntry(const int64_t size, const uint8_t* const data, const PakStreamSet_e set, StreamAddEntryResults_s& results);
@@ -31,9 +31,8 @@ private:
 
 	const CBuildSettings* m_buildSettings;
 
-	const char* m_streamCacheFileName;
-	const char* m_mandatoryStreamFileName;
-	const char* m_optionalStreamFileName;
+	std::string m_mandatoryStreamFileName;
+	std::string m_optionalStreamFileName;
 
 	CStreamCache m_streamCache;
 

--- a/src/logic/streamfile.h
+++ b/src/logic/streamfile.h
@@ -7,9 +7,8 @@
 struct StreamAddEntryResults_s
 {
 	const char* streamFile;
-
-	int64_t offset : 52;
-	int64_t index : 12;
+	int64_t dataOffset : 52;
+	int64_t pathIndex : 12;
 };
 
 class CStreamFileBuilder
@@ -23,7 +22,7 @@ public:
 	void CreateStreamFileStream(const char* const path, const PakStreamSet_e set);
 	void FinishStreamFileStream(const PakStreamSet_e set);
 
-	void AddStreamingDataEntry(const int64_t size, const uint8_t* const data, const PakStreamSet_e set, StreamAddEntryResults_s& results);
+	bool AddStreamingDataEntry(const int64_t size, const uint8_t* const data, const PakStreamSet_e set, StreamAddEntryResults_s& results);
 
 	inline size_t GetMandatoryStreamingAssetCount() const { return m_mandatoryStreamingDataBlocks.size(); };
 	inline size_t GetOptionalStreamingAssetCount() const { return m_optionalStreamingDataBlocks.size(); };

--- a/src/pch.h
+++ b/src/pch.h
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <unordered_map>
 #include <set>
+#include <unordered_set>
 //#include <sysinfoapi.h>
 #include <vector>
 #include <cstdint>

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -49,10 +49,10 @@ size_t Utils::WriteStringVector(BinaryIO& out, const std::vector<std::string>& d
 	for (auto it = dataVector.begin(); it != dataVector.end(); ++it)
 	{
 		// NOTE: +1 because we need to take the null char into account too.
-		const size_t lenPath = (*it).length() + 1;
+		const size_t lenPath = it->length() + 1;
 		lenTotal += lenPath;
 
-		out.Write((*it).c_str(), lenPath);
+		out.Write(it->c_str(), lenPath);
 	}
 	return lenTotal;
 }

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -72,9 +72,21 @@ FILETIME Utils::GetSystemFileTime()
 //-----------------------------------------------------------------------------
 void Utils::AppendSlash(std::string& in)
 {
-	char lchar = in[in.size() - 1];
+	const char lchar = in[in.size() - 1];
 	if (lchar != '\\' && lchar != '/')
 		in.append("\\");
+}
+
+//-----------------------------------------------------------------------------
+// purpose: normalizes the slash directions inside a given string
+//-----------------------------------------------------------------------------
+void Utils::FixSlashes(std::string& in, const char correctPathSeparator)
+{
+    for (char& lchar : in)
+    {
+        if (lchar == '\\' || lchar == '/')
+            lchar = correctPathSeparator;
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -107,25 +119,25 @@ void Utils::ResolvePath(std::string& outPath, const std::filesystem::path& mapPa
     }
 }
 
-const char* Utils::ExtractFileName(const char* const string)
+const char* Utils::ExtractFileName(const std::string& inPath)
 {
-    const size_t len = strlen(string);
+    const size_t len = inPath.length();
     const char* result = nullptr;
 
     for (size_t i = (len - 1); i-- > 0;)
     {
-        const char c = string[i];
+        const char c = inPath[i];
 
         if (c == '/' || c == '\\')
         {
-            result = &string[i] + 1; // +1 to advance from slash.
+            result = &inPath[i] + 1; // +1 to advance from slash.
             break;
         }
     }
 
     // No path, this is already the file name.
     if (!result)
-        result = string;
+        result = inPath.c_str();
 
     return result;
 }

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -9,10 +9,12 @@ namespace Utils
 	size_t WriteStringVector(BinaryIO& out, const std::vector<std::string>& dataVector);
 
 	void AppendSlash(std::string& in);
+	void FixSlashes(std::string& in, const char correctPathSeparator = '\\');
+
 	std::string ChangeExtension(const std::string& in, const std::string& ext);
 
 	void ResolvePath(std::string& outPath, const std::filesystem::path& mapPath);
-	const char* ExtractFileName(const char* const string);
+	const char* ExtractFileName(const std::string& inPath);
 };
 
 extern PakGuid_t Pak_ParseGuid(const rapidjson::Value& val, bool* const success = nullptr);


### PR DESCRIPTION
- Fixes corruption issue when creating patch starmaps.
- Fixes incorrect slash directions inside starpaks reference paths inside rpaks.
- Fixes an incorrect error print when streaming cache magic mismatches.
- Fixes type demotion on all calls to `MurmurHash3_x64_128()`.
- Streaming cache code cleanup (symbol naming consistency).
- Implements support for streaming file filtration for streaming data cache.