### PR TITLE
Increase max possible streaming file handles for RPak V7

### DIFF
--- a/src/logic/pakfile.cpp
+++ b/src/logic/pakfile.cpp
@@ -165,13 +165,14 @@ int64_t CPakFileBuilder::AddStreamingFileReference(const char* const path, const
 	// Check if we don't overflow the maximum the runtime supports per set.
 	// mandatory and optional are separate sets.
 	const size_t newSize = vec.size() + 1;
+	const size_t maxSize = GetMaxStreamingFileHandlesPerSet();
 
-	if (newSize > PAK_MAX_STREAMING_FILE_HANDLES_PER_SET)
+	if (newSize > maxSize)
 	{
 		const char* const streamSetName = Pak_StreamSetToName(mandatory ? PakStreamSet_e::STREAMING_SET_MANDATORY : PakStreamSet_e::STREAMING_SET_OPTIONAL);
 
 		Error("Out of room while adding %s streaming file \"%s\"; runtime has a limit of %zu, got %zu.\n",
-			streamSetName, path, PAK_MAX_STREAMING_FILE_HANDLES_PER_SET, newSize);
+			streamSetName, path, maxSize, newSize);
 	}
 
 	vec.emplace_back(path);

--- a/src/logic/pakfile.h
+++ b/src/logic/pakfile.h
@@ -66,6 +66,13 @@ public:
 		m_Header.fileVersion = version;
 	}
 
+	inline size_t GetMaxStreamingFileHandlesPerSet() const
+	{
+		return GetVersion() == 7
+			? PAK_MAX_STREAMING_FILE_HANDLES_PER_SET_V7
+			: PAK_MAX_STREAMING_FILE_HANDLES_PER_SET_V8;
+	}
+
 	inline void SetStarpakPathsSize(uint16_t len, uint16_t optLen)
 	{
 		m_Header.starpakPathsSize = len;

--- a/src/public/rpak.h
+++ b/src/public/rpak.h
@@ -20,7 +20,8 @@
 
 // max amount of streaming files that could be opened per set for a pak, so if a
 // pak uses more than one set, this number would be used per set.
-#define PAK_MAX_STREAMING_FILE_HANDLES_PER_SET 4
+#define PAK_MAX_STREAMING_FILE_HANDLES_PER_SET_V7 13 // DLC #12 allows for max 13 streaming file handles to be loaded.
+#define PAK_MAX_STREAMING_FILE_HANDLES_PER_SET_V8 4  // Since V8, the maximum has been decreased to 4 per set.
 
 #define TYPE_ANIR	MAKE_FOURCC('a', 'n', 'i', 'r') // anir
 #define TYPE_TXTR	MAKE_FOURCC('t', 'x', 't', 'r') // txtr


### PR DESCRIPTION
RPak V7 on DLC12 can have max 13 streaming file handles per pak.