### PR TITLE
Change bit for ZStd encoder as Oodle uses 1<<9

### DIFF
--- a/src/application/repak.cpp
+++ b/src/application/repak.cpp
@@ -228,7 +228,7 @@ static void RePak_HandleCompressPak(const char* const pakPath, const int compres
 
     PakHdr_t* const hdr = (PakHdr_t*)tempHdrBuf;
 
-    if (hdr->flags & (PAK_HEADER_FLAGS_RTECH_ENCODED | PAK_HEADER_FLAGS_ZSTD_ENCODED))
+    if (hdr->flags & (PAK_HEADER_FLAGS_RTECH_ENCODED | PAK_HEADER_FLAGS_OODLE_ENCODED | PAK_HEADER_FLAGS_ZSTD_ENCODED))
         Error("Pak file \"%s\" is already encoded using %s!\n", pakPath, Pak_EncodeAlgorithmToString(hdr->flags));
 
     const size_t newSize = Pak_EncodeStreamAndSwap(bio, compressLevel, workerCount, version, pakPath);
@@ -260,7 +260,7 @@ static void RePak_HandleDecompressPak(const char* const pakPath)
     PakHdr_t* const hdr = (PakHdr_t*)tempHdrBuf;
 
     // TODO: support these are well.
-    if (hdr->flags & PAK_HEADER_FLAGS_RTECH_ENCODED)
+    if (hdr->flags & (PAK_HEADER_FLAGS_RTECH_ENCODED | PAK_HEADER_FLAGS_OODLE_ENCODED))
         Error("Pak file \"%s\" is encoded using %s which is unsupported!\n", pakPath, Pak_EncodeAlgorithmToString(hdr->flags));
 
     if (!(hdr->flags & PAK_HEADER_FLAGS_ZSTD_ENCODED))

--- a/src/logic/pakfile.h
+++ b/src/logic/pakfile.h
@@ -212,6 +212,8 @@ inline const char* Pak_EncodeAlgorithmToString(const uint16_t flags)
 {
 	if (flags & PAK_HEADER_FLAGS_RTECH_ENCODED)
 		return "RTech";
+	if (flags & PAK_HEADER_FLAGS_OODLE_ENCODED)
+		return "Oodle";
 	if (flags & PAK_HEADER_FLAGS_ZSTD_ENCODED)
 		return "ZStd";
 

--- a/src/public/rpak.h
+++ b/src/public/rpak.h
@@ -14,7 +14,8 @@
 
 #define PAK_HEADER_FLAGS_HAS_MODULE    (1<<0) // instructs the runtime to load the library corresponding to this RPak.
 #define PAK_HEADER_FLAGS_RTECH_ENCODED (1<<8) // use the RTech decoder in the runtime.
-#define PAK_HEADER_FLAGS_ZSTD_ENCODED  (1<<9) // use the ZStd decoder in the runtime.
+#define PAK_HEADER_FLAGS_OODLE_ENCODED (1<<9) // use the Oodle decoder in the runtime.
+#define PAK_HEADER_FLAGS_ZSTD_ENCODED  (1<<15) // use the ZStd decoder in the runtime.
 
 #define PAK_MAX_STEM_PATH 512
 


### PR DESCRIPTION
Respawn started using 1<<9 for Oodle 2 weeks after the R5sdk implemented ZStd using the same flag. Use the last bit for ZStd to fix the current conflict and avoid future conflicts. Lets hope they won't use this bit!