### PR TITLE
Implement support for LCD screen effect assets

### DIFF
--- a/src/RePak.vcxproj
+++ b/src/RePak.vcxproj
@@ -17,6 +17,7 @@
     <ClCompile Include="assets\animseq.cpp" />
     <ClCompile Include="assets\anim_recording.cpp" />
     <ClCompile Include="assets\datatable.cpp" />
+    <ClCompile Include="assets\lcd_screen_effect.cpp" />
     <ClCompile Include="assets\material.cpp" />
     <ClCompile Include="assets\material_for_aspect.cpp" />
     <ClCompile Include="assets\model.cpp" />
@@ -188,6 +189,7 @@
     <ClInclude Include="pch.h" />
     <ClInclude Include="public\animrig.h" />
     <ClInclude Include="public\anim_recording.h" />
+    <ClInclude Include="public\lcd_screen_effect.h" />
     <ClInclude Include="public\material.h" />
     <ClInclude Include="public\materialflags.h" />
     <ClInclude Include="public\material_for_aspect.h" />
@@ -301,6 +303,7 @@
     <ProjectGuid>{4353f586-1a95-453b-847c-698083954dc7}</ProjectGuid>
     <RootNamespace>RePak</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectName>repak</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/RePak.vcxproj.filters
+++ b/src/RePak.vcxproj.filters
@@ -247,6 +247,9 @@
     <ClCompile Include="assets\ui_image_atlas.cpp">
       <Filter>assets</Filter>
     </ClCompile>
+    <ClCompile Include="assets\lcd_screen_effect.cpp">
+      <Filter>assets</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="assets\assets.h">
@@ -601,6 +604,9 @@
       <Filter>public</Filter>
     </ClInclude>
     <ClInclude Include="public\texture_list.h">
+      <Filter>public</Filter>
+    </ClInclude>
+    <ClInclude Include="public\lcd_screen_effect.h">
       <Filter>public</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -8,6 +8,7 @@
 #define TXAN_VERSION 1
 #define TXLS_VERSION 1
 #define UIMG_VERSION 10
+#define RLCD_VERSION 0
 //#define DTBL_VERSION 1
 #define STLT_VERSION 0
 #define STGS_VERSION 1
@@ -33,6 +34,7 @@ namespace Assets
 	void AddMaterialForAspectAsset_v3(CPakFileBuilder* const pak, const PakGuid_t assetGuid, const char* const assetPath, const rapidjson::Value& mapEntry);
 
 	void AddUIImageAsset_v10(CPakFileBuilder* const pak, const PakGuid_t assetGuid, const char* const assetPath, const rapidjson::Value& mapEntry);
+	void AddLcdScreenEffect_v0(CPakFileBuilder* const pak, const PakGuid_t assetGuid, const char* const assetPath, const rapidjson::Value& mapEntry);
 
 	void AddDataTableAsset(CPakFileBuilder* const pak, const PakGuid_t assetGuid, const char* const assetPath, const rapidjson::Value& mapEntry);
 	void AddSettingsLayout_v0(CPakFileBuilder* const pak, const PakGuid_t assetGuid, const char* const assetPath, const rapidjson::Value& mapEntry);

--- a/src/assets/lcd_screen_effect.cpp
+++ b/src/assets/lcd_screen_effect.cpp
@@ -1,0 +1,40 @@
+#include "pch.h"
+#include "assets.h"
+#include "public/lcd_screen_effect.h"
+
+static void LcdScreenEffect_InternalAddRLCD(CPakFileBuilder* const pak, const PakGuid_t assetGuid, const char* const assetPath)
+{
+	const std::string rlcdPath = Utils::ChangeExtension(pak->GetAssetPath() + assetPath, "json");
+	rapidjson::Document document;
+
+	if (!JSON_ParseFromFile(rlcdPath.c_str(), "lcd screen effect", document, false))
+		Error("Failed to open lcd_screen_effect asset \"%s\".\n", rlcdPath.c_str());
+
+	PakAsset_t& asset = pak->BeginAsset(assetGuid, assetPath);
+	PakPageLump_s hdrLump = pak->CreatePageLump(sizeof(LcdScreenEffect_s), SF_HEAD | SF_CLIENT, 4);
+
+	LcdScreenEffect_s* const rlcd = reinterpret_cast<LcdScreenEffect_s*>(hdrLump.data);
+
+	rlcd->interlaceX = JSON_GetNumberRequired<float>(document, "interlaceX");
+	rlcd->interlaceY = JSON_GetNumberRequired<float>(document, "interlaceY");
+	rlcd->attenuation = JSON_GetNumberRequired<float>(document, "attenuation");
+	rlcd->contrast = JSON_GetNumberRequired<float>(document, "contrast");
+	rlcd->gamma = JSON_GetNumberRequired<float>(document, "gamma");
+	rlcd->washout = JSON_GetNumberRequired<float>(document, "washout");
+	rlcd->shutterBandingIntensity = JSON_GetNumberRequired<float>(document, "shutterBandingIntensity");
+	rlcd->shutterBandingFrequency = JSON_GetNumberRequired<float>(document, "shutterBandingFrequency");
+	rlcd->shutterBandingSpacing = JSON_GetNumberRequired<float>(document, "shutterBandingSpacing");
+	rlcd->exposure = JSON_GetNumberRequired<float>(document, "exposure");
+	rlcd->reserved = JSON_GetNumberOrDefault(document, "reserved", 0);
+	rlcd->noiseAmount = JSON_GetNumberRequired<float>(document, "noiseAmount");
+
+	asset.InitAsset(hdrLump.GetPointer(), sizeof(LcdScreenEffect_s), PagePtr_t::NullPtr(), RLCD_VERSION, AssetType::RLCD);
+	asset.SetHeaderPointer(hdrLump.data);
+
+	pak->FinishAsset();
+}
+
+void Assets::AddLcdScreenEffect_v0(CPakFileBuilder* const pak, const PakGuid_t assetGuid, const char* const assetPath, const rapidjson::Value& /*mapEntry*/)
+{
+	LcdScreenEffect_InternalAddRLCD(pak, assetGuid, assetPath);
+}

--- a/src/assets/material_for_aspect.cpp
+++ b/src/assets/material_for_aspect.cpp
@@ -28,7 +28,7 @@ static void Material4Aspect_InternalAdd(CPakFileBuilder* const pak, const PakGui
 
 	MaterialForAspect_s* const mt4a = reinterpret_cast<MaterialForAspect_s*>(hdrLump.data);
 
-	int matIndex = -1;
+	int64_t matIndex = -1;
 	for (const auto& material : materialArray)
 	{
 		matIndex++;

--- a/src/logic/pakfile.cpp
+++ b/src/logic/pakfile.cpp
@@ -57,12 +57,6 @@ bool CPakFileBuilder::AddJSONAsset(const char* const targetType, const char* con
 		const steady_clock::time_point start = high_resolution_clock::now();
 		const PakGuid_t assetGuid = Pak_GetGuidOverridable(file, assetPath);
 
-		uint32_t slotIndex;
-		const PakAsset_t* const existingAsset = GetAssetByGuid(assetGuid, &slotIndex, true);
-
-		if (existingAsset)
-			Error("'%s' asset \"%s\" with GUID 0x%llX was already added in slot #%u.\n", assetType, assetPath, assetGuid, slotIndex);
-
 		targetFunc(this, assetGuid, assetPath, file);
 		const steady_clock::time_point stop = high_resolution_clock::now();
 
@@ -444,9 +438,9 @@ PakPageLump_s CPakFileBuilder::CreatePageLump(const size_t size, const int flags
 // purpose: 
 // returns: 
 //-----------------------------------------------------------------------------
-PakAsset_t* CPakFileBuilder::GetAssetByGuid(const PakGuid_t guid, uint32_t* const idx /*= nullptr*/, const bool silent /*= false*/)
+PakAsset_t* CPakFileBuilder::GetAssetByGuid(const PakGuid_t guid, size_t* const idx /*= nullptr*/, const bool silent /*= false*/)
 {
-	uint32_t i = 0;
+	size_t i = 0;
 	for (PakAsset_t& it : m_assets)
 	{
 		if (it.guid == guid)

--- a/src/logic/pakfile.cpp
+++ b/src/logic/pakfile.cpp
@@ -97,7 +97,9 @@ void CPakFileBuilder::AddAsset(const rapidjson::Value& file)
 
 	HANDLE_ASSET_TYPE("txtr", assetType, assetPath, AssetScope_e::kClientOnly, file, Assets::AddTextureAsset_v8, Assets::AddTextureAsset_v8);
 	HANDLE_ASSET_TYPE("txan", assetType, assetPath, AssetScope_e::kClientOnly, file, nullptr, Assets::AddTextureAnimAsset_v1);
+
 	HANDLE_ASSET_TYPE("uimg", assetType, assetPath, AssetScope_e::kClientOnly, file, Assets::AddUIImageAsset_v10, Assets::AddUIImageAsset_v10);
+	HANDLE_ASSET_TYPE("rlcd", assetType, assetPath, AssetScope_e::kClientOnly, file, Assets::AddLcdScreenEffect_v0, Assets::AddLcdScreenEffect_v0);
 
 	HANDLE_ASSET_TYPE("matl", assetType, assetPath, AssetScope_e::kClientOnly, file, Assets::AddMaterialAsset_v12, Assets::AddMaterialAsset_v15);
 	HANDLE_ASSET_TYPE("mt4a", assetType, assetPath, AssetScope_e::kClientOnly, file, nullptr, Assets::AddMaterialForAspectAsset_v3);

--- a/src/public/lcd_screen_effect.h
+++ b/src/public/lcd_screen_effect.h
@@ -1,0 +1,17 @@
+#pragma once
+
+struct LcdScreenEffect_s
+{
+	float interlaceX;
+	float interlaceY;
+	float attenuation;
+	float contrast;
+	float gamma;
+	float washout;
+	float shutterBandingIntensity;
+	float shutterBandingFrequency;
+	float shutterBandingSpacing;
+	float exposure;
+	int reserved; // [amos]: always 0 and appears to do nothing in the runtime.
+	float noiseAmount;
+};

--- a/src/public/rpak.h
+++ b/src/public/rpak.h
@@ -30,6 +30,7 @@
 #define TYPE_TXLS	MAKE_FOURCC('t', 'x', 'l', 's') // txls
 #define TYPE_RMDL	MAKE_FOURCC('m', 'd', 'l', '_') // mdl_
 #define TYPE_UIMG	MAKE_FOURCC('u', 'i', 'm', 'g') // uimg
+#define TYPE_RLCD	MAKE_FOURCC('r', 'l', 'c', 'd') // rlcd
 #define TYPE_PTCH	MAKE_FOURCC('P', 't', 'c', 'h') // Ptch
 #define TYPE_DTBL	MAKE_FOURCC('d', 't', 'b', 'l') // dtbl
 #define TYPE_STLT	MAKE_FOURCC('s', 't', 'l', 't') // stlt
@@ -51,6 +52,7 @@ enum class AssetType : uint32_t
 	TXLS = TYPE_TXLS, // texture list
 	RMDL = TYPE_RMDL, // model
 	UIMG = TYPE_UIMG, // ui image atlas
+	RLCD = TYPE_RLCD, // lcd screen effect
 	PTCH = TYPE_PTCH, // patch
 	DTBL = TYPE_DTBL, // datatable
 	STLT = TYPE_STLT, // settings layout

--- a/src/utils/jsonutils.h
+++ b/src/utils/jsonutils.h
@@ -415,7 +415,7 @@ inline bool JSON_StringToNumber(const char* const str, const size_t len, V& num)
     else
         static_assert(std::is_same_v<V, void>, "Cannot classify numeric type; unsupported.");
 
-    return (result.ptr == end) && (result.ec == std::errc());
+    return (result.ec == std::errc()) && (result.ptr == end);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/utils/jsonutils.h
+++ b/src/utils/jsonutils.h
@@ -114,7 +114,7 @@ inline const char* JSON_TypeToString(const JSONFieldType_e type)
 }
 
 template <class T>
-inline bool JSON_TypeToString(const T& data)
+inline const char* JSON_TypeToString(const T& data)
 {
     return JSON_TypeToString(JSON_ExtractType(data));
 }


### PR DESCRIPTION
Full support for custom LCD screen effect assets:
![rlcd_v5](https://github.com/user-attachments/assets/c8103224-072a-4fd9-aa1f-732094a7d25a)

Here is an example for what the program expect for LCD screen effect assets:
```json
{
	"interlaceX": 1.000000,
	"interlaceY": 1.100000,
	"attenuation": 0.250000,
	"contrast": 0.150000,
	"gamma": 3.400000,
	"washout": 0.000000,
	"shutterBandingIntensity": 0.100000,
	"shutterBandingFrequency": 2.000000,
	"shutterBandingSpacing": 4.000000,
	"exposure": 0.500000,
	"reserved": 0,
	"noiseAmount": 0.000000
}
```
Mostly used for drones and vehicle cockpits (titans, etc..).
