### PR TITLE
Asset handler lookup performance improvement

### DIFF
--- a/src/RePak.vcxproj
+++ b/src/RePak.vcxproj
@@ -17,6 +17,7 @@
     <ClCompile Include="assets\animseq.cpp" />
     <ClCompile Include="assets\anim_recording.cpp" />
     <ClCompile Include="assets\datatable.cpp" />
+    <ClCompile Include="assets\lcd_screen_effect.cpp" />
     <ClCompile Include="assets\material.cpp" />
     <ClCompile Include="assets\material_for_aspect.cpp" />
     <ClCompile Include="assets\model.cpp" />
@@ -188,6 +189,7 @@
     <ClInclude Include="pch.h" />
     <ClInclude Include="public\animrig.h" />
     <ClInclude Include="public\anim_recording.h" />
+    <ClInclude Include="public\lcd_screen_effect.h" />
     <ClInclude Include="public\material.h" />
     <ClInclude Include="public\materialflags.h" />
     <ClInclude Include="public\material_for_aspect.h" />
@@ -301,6 +303,7 @@
     <ProjectGuid>{4353f586-1a95-453b-847c-698083954dc7}</ProjectGuid>
     <RootNamespace>RePak</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectName>repak</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/RePak.vcxproj.filters
+++ b/src/RePak.vcxproj.filters
@@ -247,6 +247,9 @@
     <ClCompile Include="assets\ui_image_atlas.cpp">
       <Filter>assets</Filter>
     </ClCompile>
+    <ClCompile Include="assets\lcd_screen_effect.cpp">
+      <Filter>assets</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="assets\assets.h">
@@ -601,6 +604,9 @@
       <Filter>public</Filter>
     </ClInclude>
     <ClInclude Include="public\texture_list.h">
+      <Filter>public</Filter>
+    </ClInclude>
+    <ClInclude Include="public\lcd_screen_effect.h">
       <Filter>public</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -8,6 +8,7 @@
 #define TXAN_VERSION 1
 #define TXLS_VERSION 1
 #define UIMG_VERSION 10
+#define RLCD_VERSION 0
 //#define DTBL_VERSION 1
 #define STLT_VERSION 0
 #define STGS_VERSION 1
@@ -33,6 +34,7 @@ namespace Assets
 	void AddMaterialForAspectAsset_v3(CPakFileBuilder* const pak, const PakGuid_t assetGuid, const char* const assetPath, const rapidjson::Value& mapEntry);
 
 	void AddUIImageAsset_v10(CPakFileBuilder* const pak, const PakGuid_t assetGuid, const char* const assetPath, const rapidjson::Value& mapEntry);
+	void AddLcdScreenEffect_v0(CPakFileBuilder* const pak, const PakGuid_t assetGuid, const char* const assetPath, const rapidjson::Value& mapEntry);
 
 	void AddDataTableAsset(CPakFileBuilder* const pak, const PakGuid_t assetGuid, const char* const assetPath, const rapidjson::Value& mapEntry);
 	void AddSettingsLayout_v0(CPakFileBuilder* const pak, const PakGuid_t assetGuid, const char* const assetPath, const rapidjson::Value& mapEntry);

--- a/src/assets/lcd_screen_effect.cpp
+++ b/src/assets/lcd_screen_effect.cpp
@@ -1,0 +1,40 @@
+#include "pch.h"
+#include "assets.h"
+#include "public/lcd_screen_effect.h"
+
+static void LcdScreenEffect_InternalAddRLCD(CPakFileBuilder* const pak, const PakGuid_t assetGuid, const char* const assetPath)
+{
+	const std::string rlcdPath = Utils::ChangeExtension(pak->GetAssetPath() + assetPath, "json");
+	rapidjson::Document document;
+
+	if (!JSON_ParseFromFile(rlcdPath.c_str(), "lcd screen effect", document, false))
+		Error("Failed to open lcd_screen_effect asset \"%s\".\n", rlcdPath.c_str());
+
+	PakAsset_t& asset = pak->BeginAsset(assetGuid, assetPath);
+	PakPageLump_s hdrLump = pak->CreatePageLump(sizeof(LcdScreenEffect_s), SF_HEAD | SF_CLIENT, 4);
+
+	LcdScreenEffect_s* const rlcd = reinterpret_cast<LcdScreenEffect_s*>(hdrLump.data);
+
+	rlcd->interlaceX = JSON_GetNumberRequired<float>(document, "interlaceX");
+	rlcd->interlaceY = JSON_GetNumberRequired<float>(document, "interlaceY");
+	rlcd->attenuation = JSON_GetNumberRequired<float>(document, "attenuation");
+	rlcd->contrast = JSON_GetNumberRequired<float>(document, "contrast");
+	rlcd->gamma = JSON_GetNumberRequired<float>(document, "gamma");
+	rlcd->washout = JSON_GetNumberRequired<float>(document, "washout");
+	rlcd->shutterBandingIntensity = JSON_GetNumberRequired<float>(document, "shutterBandingIntensity");
+	rlcd->shutterBandingFrequency = JSON_GetNumberRequired<float>(document, "shutterBandingFrequency");
+	rlcd->shutterBandingSpacing = JSON_GetNumberRequired<float>(document, "shutterBandingSpacing");
+	rlcd->exposure = JSON_GetNumberRequired<float>(document, "exposure");
+	rlcd->reserved = JSON_GetNumberOrDefault(document, "reserved", 0);
+	rlcd->noiseAmount = JSON_GetNumberRequired<float>(document, "noiseAmount");
+
+	asset.InitAsset(hdrLump.GetPointer(), sizeof(LcdScreenEffect_s), PagePtr_t::NullPtr(), RLCD_VERSION, AssetType::RLCD);
+	asset.SetHeaderPointer(hdrLump.data);
+
+	pak->FinishAsset();
+}
+
+void Assets::AddLcdScreenEffect_v0(CPakFileBuilder* const pak, const PakGuid_t assetGuid, const char* const assetPath, const rapidjson::Value& /*mapEntry*/)
+{
+	LcdScreenEffect_InternalAddRLCD(pak, assetGuid, assetPath);
+}

--- a/src/assets/material_for_aspect.cpp
+++ b/src/assets/material_for_aspect.cpp
@@ -28,7 +28,7 @@ static void Material4Aspect_InternalAdd(CPakFileBuilder* const pak, const PakGui
 
 	MaterialForAspect_s* const mt4a = reinterpret_cast<MaterialForAspect_s*>(hdrLump.data);
 
-	int matIndex = -1;
+	int64_t matIndex = -1;
 	for (const auto& material : materialArray)
 	{
 		matIndex++;

--- a/src/logic/pakfile.cpp
+++ b/src/logic/pakfile.cpp
@@ -57,12 +57,6 @@ bool CPakFileBuilder::AddJSONAsset(const char* const targetType, const char* con
 		const steady_clock::time_point start = high_resolution_clock::now();
 		const PakGuid_t assetGuid = Pak_GetGuidOverridable(file, assetPath);
 
-		uint32_t slotIndex;
-		const PakAsset_t* const existingAsset = GetAssetByGuid(assetGuid, &slotIndex, true);
-
-		if (existingAsset)
-			Error("'%s' asset \"%s\" with GUID 0x%llX was already added in slot #%u.\n", assetType, assetPath, assetGuid, slotIndex);
-
 		targetFunc(this, assetGuid, assetPath, file);
 		const steady_clock::time_point stop = high_resolution_clock::now();
 
@@ -444,9 +438,9 @@ PakPageLump_s CPakFileBuilder::CreatePageLump(const size_t size, const int flags
 // purpose: 
 // returns: 
 //-----------------------------------------------------------------------------
-PakAsset_t* CPakFileBuilder::GetAssetByGuid(const PakGuid_t guid, uint32_t* const idx /*= nullptr*/, const bool silent /*= false*/)
+PakAsset_t* CPakFileBuilder::GetAssetByGuid(const PakGuid_t guid, size_t* const idx /*= nullptr*/, const bool silent /*= false*/)
 {
-	uint32_t i = 0;
+	size_t i = 0;
 	for (PakAsset_t& it : m_assets)
 	{
 		if (it.guid == guid)

--- a/src/logic/pakfile.cpp
+++ b/src/logic/pakfile.cpp
@@ -102,14 +102,10 @@ void CPakFileBuilder::AddAsset(const rapidjson::Value& file)
 	const auto it = s_pakAssetHandlers.find({ assetType });
 
 	if (it == s_pakAssetHandlers.end())
-	{
 		Error("Unhandled asset type '%.4s' provided.\n", assetType);
-		g_currentAsset = nullptr;
+	else
+		AddJSONAsset(*it, assetPath, file);
 
-		return;
-	}
-
-	AddJSONAsset(*it, assetPath, file);
 	g_currentAsset = nullptr;
 }
 

--- a/src/logic/pakfile.cpp
+++ b/src/logic/pakfile.cpp
@@ -15,44 +15,61 @@ CPakFileBuilder::CPakFileBuilder(const CBuildSettings* const buildSettings, CStr
 	m_streamBuilder = streamBuilder;
 }
 
-bool CPakFileBuilder::AddJSONAsset(const char* const targetType, const char* const assetType, const char* const assetPath,
-							const AssetScope_e assetScope, const rapidjson::Value& file, AssetTypeFunc_t func_r2, AssetTypeFunc_t func_r5)
+static std::unordered_set<PakAssetHandler_s, PakAssetHasher_s> s_pakAssetHandlers
 {
-	if (strcmp(targetType, assetType) != 0)
-		return false;
+	{"anir", PakAssetScope_e::kServerOnly, Assets::AddAnimRecording_v1, Assets::AddAnimRecording_v1},
+	{"txtr", PakAssetScope_e::kClientOnly, Assets::AddTextureAsset_v8, Assets::AddTextureAsset_v8},
+	{"txan", PakAssetScope_e::kClientOnly, nullptr, Assets::AddTextureAnimAsset_v1},
+	{"uimg", PakAssetScope_e::kClientOnly, Assets::AddUIImageAsset_v10, Assets::AddUIImageAsset_v10},
+	{"rlcd", PakAssetScope_e::kClientOnly, Assets::AddLcdScreenEffect_v0, Assets::AddLcdScreenEffect_v0},
+	{"matl", PakAssetScope_e::kClientOnly, Assets::AddMaterialAsset_v12, Assets::AddMaterialAsset_v15},
+	{"mt4a", PakAssetScope_e::kClientOnly, nullptr, Assets::AddMaterialForAspectAsset_v3},
+	{"shdr", PakAssetScope_e::kClientOnly, Assets::AddShaderAsset_v8, Assets::AddShaderAsset_v12},
+	{"shds", PakAssetScope_e::kClientOnly, Assets::AddShaderSetAsset_v8, Assets::AddShaderSetAsset_v11},
+	{"dtbl", PakAssetScope_e::kAll, Assets::AddDataTableAsset, Assets::AddDataTableAsset},
+	{"stlt", PakAssetScope_e::kAll, nullptr, Assets::AddSettingsLayout_v0},
+	{"stgs", PakAssetScope_e::kAll, nullptr, Assets::AddSettingsAsset_v1},
+	{"mdl_", PakAssetScope_e::kAll, nullptr, Assets::AddModelAsset_v9},
+	{"aseq", PakAssetScope_e::kAll, nullptr, Assets::AddAnimSeqAsset_v7},
+	{"arig", PakAssetScope_e::kAll, nullptr, Assets::AddAnimRigAsset_v4},
+	{"txls", PakAssetScope_e::kAll, nullptr, Assets::AddTextureListAsset_v1},
+	{"Ptch", PakAssetScope_e::kAll, Assets::AddPatchAsset, Assets::AddPatchAsset}
+};
 
-	switch (assetScope)
+void CPakFileBuilder::AddJSONAsset(const PakAssetHandler_s& assetHandler, const char* const assetPath, const rapidjson::Value& file)
+{
+	switch (assetHandler.assetScope)
 	{
-	case AssetScope_e::kServerOnly:
+	case PakAssetScope_e::kServerOnly:
 		if (!IsFlagSet(PF_KEEP_SERVER))
-			return true;
+			return;
 		break;
-	case AssetScope_e::kClientOnly:
+	case PakAssetScope_e::kClientOnly:
 		if (!IsFlagSet(PF_KEEP_CLIENT))
-			return true;
+			return;
 		break;
 	}
 
-	AssetTypeFunc_t targetFunc = nullptr;
+	PakAssetAddFunc_t targetFunc = nullptr;
 	const uint16_t fileVersion = this->m_Header.fileVersion;
 
 	switch (fileVersion)
 	{
 	case 7:
 	{
-		targetFunc = func_r2;
+		targetFunc = assetHandler.func_r2;
 		break;
 	}
 	case 8:
 	{
-		targetFunc = func_r5;
+		targetFunc = assetHandler.func_r5;
 		break;
 	}
 	}
 
 	if (targetFunc)
 	{
-		Debug("Adding '%s' asset \"%s\".\n", assetType, assetPath);
+		Debug("Adding '%s' asset \"%s\".\n", assetHandler.assetType, assetPath);
 
 		const steady_clock::time_point start = high_resolution_clock::now();
 		const PakGuid_t assetGuid = Pak_GetGuidOverridable(file, assetPath);
@@ -64,18 +81,8 @@ bool CPakFileBuilder::AddJSONAsset(const char* const targetType, const char* con
 		Debug("...done; took %lld ms.\n", duration.count());
 	}
 	else
-		Error("Asset type '%.4s' is not supported on pak version %hu.\n", assetType, fileVersion);
-
-	// Asset type has been handled.
-	return true;
+		Error("Asset type '%.4s' is not supported on pak version %hu.\n", assetHandler.assetType, fileVersion);
 }
-
-#define HANDLE_ASSET_TYPE(targetType, assetType, assetPath, assetScope, asset, func_r2, func_r5) \
-		if (AddJSONAsset(targetType, assetType, assetPath, assetScope, asset, func_r2, func_r5)) \
-			{ \
-				g_currentAsset = nullptr; \
-				return; \
-			}
 
 //-----------------------------------------------------------------------------
 // purpose: installs asset types and their callbacks
@@ -92,36 +99,18 @@ void CPakFileBuilder::AddAsset(const rapidjson::Value& file)
 		Error("No path provided for an asset of type '%.4s'.\n", assetType);
 
 	g_currentAsset = assetPath;
+	const auto it = s_pakAssetHandlers.find({ assetType });
 
-	HANDLE_ASSET_TYPE("anir", assetType, assetPath, AssetScope_e::kServerOnly, file, Assets::AddAnimRecording_v1, Assets::AddAnimRecording_v1);
+	if (it == s_pakAssetHandlers.end())
+	{
+		Error("Unhandled asset type '%.4s' provided.\n", assetType);
+		g_currentAsset = nullptr;
 
-	HANDLE_ASSET_TYPE("txtr", assetType, assetPath, AssetScope_e::kClientOnly, file, Assets::AddTextureAsset_v8, Assets::AddTextureAsset_v8);
-	HANDLE_ASSET_TYPE("txan", assetType, assetPath, AssetScope_e::kClientOnly, file, nullptr, Assets::AddTextureAnimAsset_v1);
+		return;
+	}
 
-	HANDLE_ASSET_TYPE("uimg", assetType, assetPath, AssetScope_e::kClientOnly, file, Assets::AddUIImageAsset_v10, Assets::AddUIImageAsset_v10);
-	HANDLE_ASSET_TYPE("rlcd", assetType, assetPath, AssetScope_e::kClientOnly, file, Assets::AddLcdScreenEffect_v0, Assets::AddLcdScreenEffect_v0);
-
-	HANDLE_ASSET_TYPE("matl", assetType, assetPath, AssetScope_e::kClientOnly, file, Assets::AddMaterialAsset_v12, Assets::AddMaterialAsset_v15);
-	HANDLE_ASSET_TYPE("mt4a", assetType, assetPath, AssetScope_e::kClientOnly, file, nullptr, Assets::AddMaterialForAspectAsset_v3);
-
-	HANDLE_ASSET_TYPE("shdr", assetType, assetPath, AssetScope_e::kClientOnly, file, Assets::AddShaderAsset_v8, Assets::AddShaderAsset_v12);
-	HANDLE_ASSET_TYPE("shds", assetType, assetPath, AssetScope_e::kClientOnly, file, Assets::AddShaderSetAsset_v8, Assets::AddShaderSetAsset_v11);
-
-	HANDLE_ASSET_TYPE("dtbl", assetType, assetPath, AssetScope_e::kAll, file, Assets::AddDataTableAsset, Assets::AddDataTableAsset);
-	HANDLE_ASSET_TYPE("stlt", assetType, assetPath, AssetScope_e::kAll, file, nullptr, Assets::AddSettingsLayout_v0);
-	HANDLE_ASSET_TYPE("stgs", assetType, assetPath, AssetScope_e::kAll, file, nullptr, Assets::AddSettingsAsset_v1);
-
-	HANDLE_ASSET_TYPE("mdl_", assetType, assetPath, AssetScope_e::kAll, file, nullptr, Assets::AddModelAsset_v9);
-	HANDLE_ASSET_TYPE("aseq", assetType, assetPath, AssetScope_e::kAll, file, nullptr, Assets::AddAnimSeqAsset_v7);
-	HANDLE_ASSET_TYPE("arig", assetType, assetPath, AssetScope_e::kAll, file, nullptr, Assets::AddAnimRigAsset_v4);
-
-	HANDLE_ASSET_TYPE("txls", assetType, assetPath, AssetScope_e::kAll, file, nullptr, Assets::AddTextureListAsset_v1);
-	HANDLE_ASSET_TYPE("Ptch", assetType, assetPath, AssetScope_e::kAll, file, Assets::AddPatchAsset, Assets::AddPatchAsset);
-
+	AddJSONAsset(*it, assetPath, file);
 	g_currentAsset = nullptr;
-
-	// If the function has not returned by this point, we have an unhandled asset type.
-	Error("Unhandled asset type '%.4s' provided for asset \"%s\".\n", assetType, assetPath);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/logic/pakfile.cpp
+++ b/src/logic/pakfile.cpp
@@ -97,7 +97,9 @@ void CPakFileBuilder::AddAsset(const rapidjson::Value& file)
 
 	HANDLE_ASSET_TYPE("txtr", assetType, assetPath, AssetScope_e::kClientOnly, file, Assets::AddTextureAsset_v8, Assets::AddTextureAsset_v8);
 	HANDLE_ASSET_TYPE("txan", assetType, assetPath, AssetScope_e::kClientOnly, file, nullptr, Assets::AddTextureAnimAsset_v1);
+
 	HANDLE_ASSET_TYPE("uimg", assetType, assetPath, AssetScope_e::kClientOnly, file, Assets::AddUIImageAsset_v10, Assets::AddUIImageAsset_v10);
+	HANDLE_ASSET_TYPE("rlcd", assetType, assetPath, AssetScope_e::kClientOnly, file, Assets::AddLcdScreenEffect_v0, Assets::AddLcdScreenEffect_v0);
 
 	HANDLE_ASSET_TYPE("matl", assetType, assetPath, AssetScope_e::kClientOnly, file, Assets::AddMaterialAsset_v12, Assets::AddMaterialAsset_v15);
 	HANDLE_ASSET_TYPE("mt4a", assetType, assetPath, AssetScope_e::kClientOnly, file, nullptr, Assets::AddMaterialForAspectAsset_v3);

--- a/src/public/lcd_screen_effect.h
+++ b/src/public/lcd_screen_effect.h
@@ -1,0 +1,17 @@
+#pragma once
+
+struct LcdScreenEffect_s
+{
+	float interlaceX;
+	float interlaceY;
+	float attenuation;
+	float contrast;
+	float gamma;
+	float washout;
+	float shutterBandingIntensity;
+	float shutterBandingFrequency;
+	float shutterBandingSpacing;
+	float exposure;
+	int reserved; // [amos]: always 0 and appears to do nothing in the runtime.
+	float noiseAmount;
+};

--- a/src/public/rpak.h
+++ b/src/public/rpak.h
@@ -30,6 +30,7 @@
 #define TYPE_TXLS	MAKE_FOURCC('t', 'x', 'l', 's') // txls
 #define TYPE_RMDL	MAKE_FOURCC('m', 'd', 'l', '_') // mdl_
 #define TYPE_UIMG	MAKE_FOURCC('u', 'i', 'm', 'g') // uimg
+#define TYPE_RLCD	MAKE_FOURCC('r', 'l', 'c', 'd') // rlcd
 #define TYPE_PTCH	MAKE_FOURCC('P', 't', 'c', 'h') // Ptch
 #define TYPE_DTBL	MAKE_FOURCC('d', 't', 'b', 'l') // dtbl
 #define TYPE_STLT	MAKE_FOURCC('s', 't', 'l', 't') // stlt
@@ -51,6 +52,7 @@ enum class AssetType : uint32_t
 	TXLS = TYPE_TXLS, // texture list
 	RMDL = TYPE_RMDL, // model
 	UIMG = TYPE_UIMG, // ui image atlas
+	RLCD = TYPE_RLCD, // lcd screen effect
 	PTCH = TYPE_PTCH, // patch
 	DTBL = TYPE_DTBL, // datatable
 	STLT = TYPE_STLT, // settings layout

--- a/src/utils/jsonutils.h
+++ b/src/utils/jsonutils.h
@@ -415,7 +415,7 @@ inline bool JSON_StringToNumber(const char* const str, const size_t len, V& num)
     else
         static_assert(std::is_same_v<V, void>, "Cannot classify numeric type; unsupported.");
 
-    return (result.ptr == end) && (result.ec == std::errc());
+    return (result.ec == std::errc()) && (result.ptr == end);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/utils/jsonutils.h
+++ b/src/utils/jsonutils.h
@@ -114,7 +114,7 @@ inline const char* JSON_TypeToString(const JSONFieldType_e type)
 }
 
 template <class T>
-inline bool JSON_TypeToString(const T& data)
+inline const char* JSON_TypeToString(const T& data)
 {
     return JSON_TypeToString(JSON_ExtractType(data));
 }


### PR DESCRIPTION
Use a hashmap instead of string compares to slightly improve lookup performance, should improve the performance slightly for RPak build maps with a large number of asset entries.