### PR TITLE
Match LCD field names with shader structure ( CBufEnginePost )

### DIFF
--- a/src/assets/lcd_screen_effect.cpp
+++ b/src/assets/lcd_screen_effect.cpp
@@ -15,18 +15,25 @@ static void LcdScreenEffect_InternalAddRLCD(CPakFileBuilder* const pak, const Pa
 
 	LcdScreenEffect_s* const rlcd = reinterpret_cast<LcdScreenEffect_s*>(hdrLump.data);
 
-	rlcd->interlaceX = JSON_GetNumberRequired<float>(document, "interlaceX");
-	rlcd->interlaceY = JSON_GetNumberRequired<float>(document, "interlaceY");
-	rlcd->attenuation = JSON_GetNumberRequired<float>(document, "attenuation");
+	// Interlacing effects.
+	rlcd->pixelScaleX1 = JSON_GetNumberRequired<float>(document, "pixelScaleX1");
+	rlcd->pixelScaleX2 = JSON_GetNumberRequired<float>(document, "pixelScaleX2");
+	rlcd->pixelScaleY = JSON_GetNumberRequired<float>(document, "pixelScaleY");
+
+	// Image effects.
+	rlcd->brightness = JSON_GetNumberRequired<float>(document, "brightness");
 	rlcd->contrast = JSON_GetNumberRequired<float>(document, "contrast");
-	rlcd->gamma = JSON_GetNumberRequired<float>(document, "gamma");
-	rlcd->washout = JSON_GetNumberRequired<float>(document, "washout");
-	rlcd->shutterBandingIntensity = JSON_GetNumberRequired<float>(document, "shutterBandingIntensity");
-	rlcd->shutterBandingFrequency = JSON_GetNumberRequired<float>(document, "shutterBandingFrequency");
-	rlcd->shutterBandingSpacing = JSON_GetNumberRequired<float>(document, "shutterBandingSpacing");
-	rlcd->exposure = JSON_GetNumberRequired<float>(document, "exposure");
-	rlcd->reserved = JSON_GetNumberOrDefault(document, "reserved", 0);
-	rlcd->noiseAmount = JSON_GetNumberRequired<float>(document, "noiseAmount");
+
+	// Shutter banding effects.
+	rlcd->waveScale = JSON_GetNumberRequired<float>(document, "waveScale");
+	rlcd->waveOffset = JSON_GetNumberRequired<float>(document, "waveOffset");
+	rlcd->waveSpeed = JSON_GetNumberRequired<float>(document, "waveSpeed");
+	rlcd->wavePeriod = JSON_GetNumberRequired<float>(document, "wavePeriod");
+
+	// Noise effects.
+	rlcd->bloomAdd = JSON_GetNumberRequired<float>(document, "bloomAdd");
+	rlcd->reserved = JSON_GetNumberOrDefault(document, "reserved", 0u);
+	rlcd->pixelFlicker = JSON_GetNumberRequired<float>(document, "pixelFlicker");
 
 	asset.InitAsset(hdrLump.GetPointer(), sizeof(LcdScreenEffect_s), PagePtr_t::NullPtr(), RLCD_VERSION, AssetType::RLCD);
 	asset.SetHeaderPointer(hdrLump.data);

--- a/src/public/lcd_screen_effect.h
+++ b/src/public/lcd_screen_effect.h
@@ -2,16 +2,16 @@
 
 struct LcdScreenEffect_s
 {
-	float interlaceX;
-	float interlaceY;
-	float attenuation;
+	float pixelScaleX1;
+	float pixelScaleX2;
+	float pixelScaleY;
+	float brightness;
 	float contrast;
-	float gamma;
-	float washout;
-	float shutterBandingIntensity;
-	float shutterBandingFrequency;
-	float shutterBandingSpacing;
-	float exposure;
-	int reserved; // [amos]: always 0 and appears to do nothing in the runtime.
-	float noiseAmount;
+	float waveScale;
+	float waveOffset;
+	float waveSpeed;
+	float wavePeriod;
+	float bloomAdd;
+	uint32_t reserved; // [amos]: always 0 and appears to do nothing in the runtime.
+	float pixelFlicker;
 };


### PR DESCRIPTION
Match the RLCD asset type field names with the member field names found in the CBufEnginePost shader structure (this is indirectly mapped to the shader). This allows for clearer documentation and avoids confusion when looking up the CBufEnginePost member variables and comparing them with the ones found in LcdScreenEffect_s.

New example of the LCD screen effect asset ( `lcd_screen_effect/lcd_titanscreen_startup.rpak` ):

```json
{
	"pixelScaleX1": -0.500000,
	"pixelScaleX2": -0.500000,
	"pixelScaleY": -0.500000,
	"brightness": -1.000000,
	"contrast": -5.000000,
	"waveScale": 0.000000,
	"waveOffset": 0.000000,
	"waveSpeed": 0.000000,
	"wavePeriod": 0.000000,
	"bloomAdd": 0.200000,
	"reserved": 0,
	"pixelFlicker": 0.400000
}
```