### PR TITLE
Struct field fixes for LcdScreenEffect_s and MaterialAsset_t

### DIFF
--- a/src/assets/lcd_screen_effect.cpp
+++ b/src/assets/lcd_screen_effect.cpp
@@ -32,7 +32,7 @@ static void LcdScreenEffect_InternalAddRLCD(CPakFileBuilder* const pak, const Pa
 
 	// Noise effects.
 	rlcd->bloomAdd = JSON_GetNumberRequired<float>(document, "bloomAdd");
-	rlcd->reserved = JSON_GetNumberOrDefault(document, "reserved", 0u);
+	rlcd->doBloomLuminance = JSON_GetValueRequired<bool>(document, "doBloomLuminance");
 	rlcd->pixelFlicker = JSON_GetNumberRequired<float>(document, "pixelFlicker");
 
 	asset.InitAsset(hdrLump.GetPointer(), sizeof(LcdScreenEffect_s), PagePtr_t::NullPtr(), RLCD_VERSION, AssetType::RLCD);

--- a/src/assets/lcd_screen_effect.cpp
+++ b/src/assets/lcd_screen_effect.cpp
@@ -25,8 +25,8 @@ static void LcdScreenEffect_InternalAddRLCD(CPakFileBuilder* const pak, const Pa
 	rlcd->contrast = JSON_GetNumberRequired<float>(document, "contrast");
 
 	// Shutter banding effects.
-	rlcd->waveScale = JSON_GetNumberRequired<float>(document, "waveScale");
 	rlcd->waveOffset = JSON_GetNumberRequired<float>(document, "waveOffset");
+	rlcd->waveScale = JSON_GetNumberRequired<float>(document, "waveScale");
 	rlcd->waveSpeed = JSON_GetNumberRequired<float>(document, "waveSpeed");
 	rlcd->wavePeriod = JSON_GetNumberRequired<float>(document, "wavePeriod");
 

--- a/src/assets/material.cpp
+++ b/src/assets/material.cpp
@@ -416,15 +416,15 @@ void MaterialAsset_t::FromJSON(const rapidjson::Value& mapEntry)
     // used for blend materials and the like
     this->surface2 = JSON_GetValueRequired<const char*>(mapEntry, "surfaceProp2");
 
+    // Set samplers properly. Responsible for texture stretching, tiling etc.
+    *(uint64_t*)this->samplers = JSON_GetNumberRequired<uint64_t>(mapEntry, "samplers");
+
     // This seems to be set on all materials, i haven't it being used yet in
     // the engine by hardware breakpointing it. but given that it was
     // preinitialized in the pak file, and the possible fact that various
     // other flags might dictate when and if this gets used, it must be
     // provided by the user.
     this->features = JSON_GetNumberRequired<uint32_t>(mapEntry, "features");
-
-    // Set samplers properly. Responsible for texture stretching, tiling etc.
-    *(uint32_t*)this->samplers = JSON_GetNumberRequired<uint32_t>(mapEntry, "samplers");
 
     Material_SetDXStates(mapEntry, dxStates);
 }

--- a/src/assets/material.cpp
+++ b/src/assets/material.cpp
@@ -417,7 +417,10 @@ void MaterialAsset_t::FromJSON(const rapidjson::Value& mapEntry)
     this->surface2 = JSON_GetValueRequired<const char*>(mapEntry, "surfaceProp2");
 
     // Set samplers properly. Responsible for texture stretching, tiling etc.
-    *(uint64_t*)this->samplers = JSON_GetNumberRequired<uint64_t>(mapEntry, "samplers");
+    if (assetVersion == 12)
+        *(uint32_t*)this->samplers = JSON_GetNumberRequired<uint32_t>(mapEntry, "samplers");
+    else // 15 uses 8 samplers, which is 64 bits total.
+        *(uint64_t*)this->samplers = JSON_GetNumberRequired<uint64_t>(mapEntry, "samplers");
 
     // This seems to be set on all materials, i haven't it being used yet in
     // the engine by hardware breakpointing it. but given that it was

--- a/src/public/lcd_screen_effect.h
+++ b/src/public/lcd_screen_effect.h
@@ -12,6 +12,6 @@ struct LcdScreenEffect_s
 	float waveSpeed;
 	float wavePeriod;
 	float bloomAdd;
-	uint32_t reserved; // [amos]: always 0 and appears to do nothing in the runtime.
+	bool doBloomLuminance;
 	float pixelFlicker;
 };

--- a/src/public/lcd_screen_effect.h
+++ b/src/public/lcd_screen_effect.h
@@ -7,8 +7,8 @@ struct LcdScreenEffect_s
 	float pixelScaleY;
 	float brightness;
 	float contrast;
-	float waveScale;
 	float waveOffset;
+	float waveScale;
 	float waveSpeed;
 	float wavePeriod;
 	float bloomAdd;

--- a/src/public/material.h
+++ b/src/public/material.h
@@ -464,10 +464,7 @@ struct __declspec(align(16)) MaterialAssetHeader_v12_t
 	PagePtr_t streamingTextureHandles; // Streamable TextureGUID Map
 	short numStreamingTextureHandles; // Number of textures with streamed mip levels.
 
-	char samplers[4]; // 0x503000
-
-	short unk_AE;
-	uint64_t unk_B0; // haven't observed anything here.
+	char samplers[8]; // 0x503000
 
 	// seems to be 0xFBA63181 for loadscreens
 	uint32_t features; // no clue tbh, 0xFBA63181
@@ -514,9 +511,7 @@ struct __declspec(align(16)) MaterialAssetHeader_v15_t
 
 	// array of indices into sampler states array. must be set properly to have accurate texture tiling
 	// used in CShaderGlue::SetupShader (1403B3C60)
-	char samplers[4];// = 0x1D0300;
-
-	uint32_t unk_7C;
+	char samplers[8];// = 0x1D0300;
 
 	// most materials have this set as '0x1F5A92BD', PTCS/PTCU
 	// materials have it set as 0x75C8DF6F typically, and in
@@ -568,10 +563,8 @@ struct MaterialAsset_t
 	short height;
 	short depth;
 
-	uint32_t unk_7C;
+	char samplers[8];
 	uint32_t features; // 0x1F5A92BD, REQUIRED but why?
-
-	char samplers[4];
 
 	uint32_t flags;
 	uint32_t flags2;
@@ -652,7 +645,6 @@ struct MaterialAsset_t
 			matl->height = this->height;
 			matl->depth = this->depth;
 
-			matl->unk_7C = this->unk_7C;
 			matl->features = this->features;
 
 			memcpy(matl->samplers, this->samplers, sizeof(matl->samplers));

--- a/src/public/material.h
+++ b/src/public/material.h
@@ -464,7 +464,10 @@ struct __declspec(align(16)) MaterialAssetHeader_v12_t
 	PagePtr_t streamingTextureHandles; // Streamable TextureGUID Map
 	short numStreamingTextureHandles; // Number of textures with streamed mip levels.
 
-	char samplers[8]; // 0x503000
+	char samplers[4]; // 0x503000
+
+	short unk_AE;
+	uint64_t unk_B0; // haven't observed anything here.
 
 	// seems to be 0xFBA63181 for loadscreens
 	uint32_t features; // no clue tbh, 0xFBA63181


### PR DESCRIPTION
Fixes incorrect order of members in LcdScreenEffect_s, and makes MaterialAsset_t::samplers 64 bit (game reads it up to 64bit in len).